### PR TITLE
ZEN-15429 - Cache tag severities

### DIFF
--- a/core/src/main/java/org/zenoss/zep/index/impl/lucene/LuceneEventIndexBackend.java
+++ b/core/src/main/java/org/zenoss/zep/index/impl/lucene/LuceneEventIndexBackend.java
@@ -84,10 +84,11 @@ public class LuceneEventIndexBackend extends BaseEventIndexBackend<LuceneSavedSe
 
     public LuceneEventIndexBackend(String name, IndexWriter writer, EventSummaryBaseDao eventSummaryBaseDao,
                                    Integer maxClauseCount, LuceneFilterCacheManager filterCacheManager, int readerRefreshInterval,
-                                   Messages messages, TaskScheduler scheduler, UUIDGenerator uuidGenerator)
+                                   Messages messages, TaskScheduler scheduler, UUIDGenerator uuidGenerator,
+                                   int tagSeverityCacheSize, int tagSeveritiesCacheTTL)
             throws IOException
     {
-        super(messages, scheduler, uuidGenerator);
+        super(messages, scheduler, uuidGenerator, tagSeverityCacheSize, tagSeveritiesCacheTTL);
         this.name = name;
         this.writer = writer;
         this.trackingIndexWriter = new TrackingIndexWriter(this.writer);

--- a/core/src/main/java/org/zenoss/zep/index/impl/solr/SolrEventIndexBackend.java
+++ b/core/src/main/java/org/zenoss/zep/index/impl/solr/SolrEventIndexBackend.java
@@ -35,14 +35,12 @@ import org.apache.solr.common.params.SolrParams;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.scheduling.TaskScheduler;
-import org.springframework.stereotype.Component;
 import org.zenoss.protobufs.zep.Zep.*;
 import org.zenoss.protobufs.zep.Zep.EventSort.Field;
 import org.zenoss.zep.Messages;
 import org.zenoss.zep.UUIDGenerator;
 import org.zenoss.zep.ZepException;
 import org.zenoss.zep.dao.EventArchiveDao;
-import org.zenoss.zep.dao.EventSummaryBaseDao;
 import org.zenoss.zep.index.IndexedDetailsConfiguration;
 import org.zenoss.zep.index.SavedSearchProcessor;
 import org.zenoss.zep.index.impl.BaseEventIndexBackend;
@@ -104,8 +102,9 @@ public class SolrEventIndexBackend extends BaseEventIndexBackend<SolrSavedSearch
     public SolrEventIndexBackend(String name, String server, IndexedDetailsConfiguration indexedDetailsConfiguration,
                                  EventArchiveDao archiveDao, int shards, int replicationFactor, int maxShardsPerNode,
                                  int concurrentUploadQueueSize, int concurrentThreads,
-                                 Messages messages, TaskScheduler scheduler, UUIDGenerator uuidGenerator) {
-        super(messages, scheduler, uuidGenerator);
+                                 Messages messages, TaskScheduler scheduler, UUIDGenerator uuidGenerator,
+                                 int tagSeverityCacheSize, int tagSeveritiesCacheTTL) {
+        super(messages, scheduler, uuidGenerator, tagSeverityCacheSize, tagSeveritiesCacheTTL);
         this.name = name;
         this.indexedDetailsConfiguration = indexedDetailsConfiguration;
         this.archiveDao = archiveDao;

--- a/core/src/main/java/org/zenoss/zep/index/impl/solr/SolrEventIndexBackendFactory.java
+++ b/core/src/main/java/org/zenoss/zep/index/impl/solr/SolrEventIndexBackendFactory.java
@@ -29,6 +29,8 @@ public class SolrEventIndexBackendFactory implements FactoryBean<SolrEventIndexB
     private int maxShardsPerNode = 0;
     private int concurrentUploadQueueSize = 10000;
     private int concurrentThreads = 4;
+    private int tagSeverityCacheSize = 0;
+    private int tagSeverityCacheTTL = 3600;
     private Messages messages;
     private TaskScheduler scheduler;
     private UUIDGenerator uuidGenerator;
@@ -63,6 +65,14 @@ public class SolrEventIndexBackendFactory implements FactoryBean<SolrEventIndexB
 
     public void setUuidGenerator(UUIDGenerator uuidGenerator) {
         this.uuidGenerator = uuidGenerator;
+    }
+
+    public void setTagSeverityCacheSize(int tagSeverityCacheSize) {
+        this.tagSeverityCacheSize = tagSeverityCacheSize;
+    }
+
+    public void setTagSeverityCacheTTL(int tagSeverityCacheTTL) {
+        this.tagSeverityCacheTTL = tagSeverityCacheTTL;
     }
 
     public void setSolrURL(String solrURL) {
@@ -129,7 +139,8 @@ public class SolrEventIndexBackendFactory implements FactoryBean<SolrEventIndexB
             maxShardsPerNode = shards;
 
         backend = new SolrEventIndexBackend(name, solrURL, config, dao, shards, replicationFactor, maxShardsPerNode,
-                concurrentUploadQueueSize, concurrentThreads, messages, scheduler, uuidGenerator);
+                concurrentUploadQueueSize, concurrentThreads, messages, scheduler, uuidGenerator, tagSeverityCacheSize,
+                tagSeverityCacheTTL);
         backend.start();
 
         return backend;

--- a/core/src/main/resources/zeneventserver.conf
+++ b/core/src/main/resources/zeneventserver.conf
@@ -217,6 +217,12 @@ zep.redis.port=6379
 # The time between posting metrics
 #zep.metrics.post.period=30s
 
+# The number of entries kept in the tag severity LRU cache
+#zep.query.tagSeverityCacheSize=0
+
+# The number of seconds after which an entry in the tag severity cache MUST expire (the system MAY refresh more often)
+#zep.query.tagSeverityCacheTTL=3600
+
 #enable using redis to configure backends and rebuilding individual backends
 #zep.backend.configure.use.redis=false
 

--- a/core/src/main/resources/zep-config-daos.xml
+++ b/core/src/main/resources/zep-config-daos.xml
@@ -165,6 +165,8 @@
         <constructor-arg ref="messages"/>
         <constructor-arg ref="scheduler"/>
         <constructor-arg ref="uuidGenerator"/>
+        <constructor-arg value="${zep.query.tagSeverityCacheSize:0}"/>
+        <constructor-arg value="${zep.query.tagSeverityCacheTTL:3600}"/>
         <property name="queryLimit" value="${zep.query.limit}" />
         <property name="indexDetailsConfiguration" ref="indexedDetailsConfiguration"/>
         <property name="luceneSearchTimeout" value="${zep.query.lucene_search_timeout:0}" />
@@ -202,6 +204,8 @@
         <constructor-arg ref="messages"/>
         <constructor-arg ref="scheduler"/>
         <constructor-arg ref="uuidGenerator"/>
+        <constructor-arg value="${zep.query.tagSeverityCacheSize:0}"/>
+        <constructor-arg value="${zep.query.tagSeverityCacheTTL:3600}"/>
         <property name="queryLimit" value="${zep.query.limit}" />
         <property name="indexDetailsConfiguration" ref="indexedDetailsConfiguration"/>
         <property name="luceneSearchTimeout" value="${zep.query.lucene_search_timeout:0}" />
@@ -221,6 +225,8 @@
         <property name="messages" ref="messages"/>
         <property name="scheduler" ref="scheduler"/>
         <property name="uuidGenerator" ref="uuidGenerator"/>
+        <property name="tagSeverityCacheSize" value="${zep.query.tagSeverityCacheSize:0}"/>
+        <property name="tagSeverityCacheTTL" value="${zep.query.tagSeverityCacheTTL:3600}"/>
     </bean>
 
     <bean id="lucene_summary" class="org.zenoss.zep.index.impl.EventIndexBackendConfiguration">


### PR DESCRIPTION
Set zep.query.tagSeverityCacheSize=10000 (for example) to enable. Default (zero) is disabled.
Set zep.query.tagSeverityCacheTTL=86400 (for example) to cache for up to 24 hours. Default (3600) is one hour.