### PR TITLE
ZEN-16442 - Add an index to event_summary(last_seen)

### DIFF
--- a/core/src/main/sql/mysql/007.sql
+++ b/core/src/main/sql/mysql/007.sql
@@ -1,0 +1,29 @@
+-- Copyright (C) 2015, Zenoss Inc.  All Rights Reserved.
+
+--
+-- Adds an index for faster aging of events from summary to archive.
+--
+
+DROP PROCEDURE IF EXISTS drop_index_if_exists;
+DELIMITER $$
+CREATE PROCEDURE drop_index_if_exists(IN tname VARCHAR(64), IN idx_name VARCHAR(64))
+BEGIN
+  IF EXISTS(SELECT 1 FROM INFORMATION_SCHEMA.STATISTICS WHERE table_schema = DATABASE()
+            AND UPPER(table_name) = tname AND UPPER(index_name) = idx_name)
+  THEN
+    SET @drop_sql = CONCAT('DROP INDEX ',idx_name,' ON ',tname,';');
+    PREPARE stmt FROM @drop_sql;
+    EXECUTE stmt;
+    DEALLOCATE PREPARE stmt;
+  END IF;
+END
+$$
+DELIMITER ;
+
+CALL drop_index_if_exists('event_summary','event_summary_last_seen');
+CALL drop_index_if_exists('event_summary','event_summary_last_seen_idx');
+CREATE INDEX event_summary_last_seen_idx ON event_summary(last_seen);
+
+DROP PROCEDURE IF EXISTS drop_index_if_exists;
+
+INSERT INTO schema_version (version, installed_time) VALUES(7, NOW());

--- a/core/src/main/sql/mysql/007.sql
+++ b/core/src/main/sql/mysql/007.sql
@@ -20,7 +20,14 @@ END
 $$
 DELIMITER ;
 
+-- If we don't delete these two, the query planner sometimes chooses to use one
+-- of them when it would be better to use event_summary_last_seen_idx.
+CALL drop_index_if_exists('event_summary','event_summary_age_idx');
+CALL drop_index_if_exists('event_summary','event_summary_archive_idx');
+
+-- At one of our customers, this index was created manually.
 CALL drop_index_if_exists('event_summary','event_summary_last_seen');
+
 CALL drop_index_if_exists('event_summary','event_summary_last_seen_idx');
 CREATE INDEX event_summary_last_seen_idx ON event_summary(last_seen);
 

--- a/core/src/main/sql/postgresql/003.sql
+++ b/core/src/main/sql/postgresql/003.sql
@@ -1,0 +1,8 @@
+--
+-- Adds an index for faster aging of events from summary to archive.
+--
+
+DROP INDEX IF EXISTS event_summary_last_seen;
+CREATE INDEX event_summary_last_seen_idx ON event_summary(last_seen);
+
+INSERT INTO schema_version (version, installed_time) VALUES(3, NOW());

--- a/core/src/main/sql/postgresql/003.sql
+++ b/core/src/main/sql/postgresql/003.sql
@@ -2,6 +2,9 @@
 -- Adds an index for faster aging of events from summary to archive.
 --
 
+DROP INDEX IF EXISTS event_summary_age_idx;
+DROP INDEX IF EXISTS event_summary_archive_idx;
+
 DROP INDEX IF EXISTS event_summary_last_seen;
 CREATE INDEX event_summary_last_seen_idx ON event_summary(last_seen);
 


### PR DESCRIPTION
I've only tested that the index gets created automatically on a fresh (zendev) install. I did not test an upgrade.

```bash
MariaDB [zenoss_zep]> show index from event_summary;
+---------------+------------+-----------------------------+--------------+------------------------+-----------+-------------+----------+--------+------+------------+---------+---------------+
| Table         | Non_unique | Key_name                    | Seq_in_index | Column_name            | Collation | Cardinality | Sub_part | Packed | Null | Index_type | Comment | Index_comment |
+---------------+------------+-----------------------------+--------------+------------------------+-----------+-------------+----------+--------+------+------------+---------+---------------+
| event_summary |          0 | PRIMARY                     |            1 | uuid                   | A         |           0 |     NULL | NULL   |      | BTREE      |         |               |
| event_summary |          0 | fingerprint_hash            |            1 | fingerprint_hash       | A         |           0 |     NULL | NULL   |      | BTREE      |         |               |
| event_summary |          1 | element_uuid                |            1 | element_uuid           | A         |           0 |     NULL | NULL   | YES  | BTREE      |         |               |
| event_summary |          1 | element_uuid                |            2 | element_type_id        | A         |           0 |     NULL | NULL   | YES  | BTREE      |         |               |
| event_summary |          1 | element_uuid                |            3 | element_identifier     | A         |           0 |     NULL | NULL   |      | BTREE      |         |               |
| event_summary |          1 | element_sub_uuid            |            1 | element_sub_uuid       | A         |           0 |     NULL | NULL   | YES  | BTREE      |         |               |
| event_summary |          1 | element_sub_uuid            |            2 | element_sub_type_id    | A         |           0 |     NULL | NULL   | YES  | BTREE      |         |               |
| event_summary |          1 | element_sub_uuid            |            3 | element_sub_identifier | A         |           0 |     NULL | NULL   | YES  | BTREE      |         |               |
| event_summary |          1 | event_summary_clear_idx     |            1 | clear_fingerprint_hash | A         |           0 |     NULL | NULL   | YES  | BTREE      |         |               |
| event_summary |          1 | event_summary_clear_idx     |            2 | status_id              | A         |           0 |     NULL | NULL   |      | BTREE      |         |               |
| event_summary |          1 | event_summary_clear_idx     |            3 | last_seen              | A         |           0 |     NULL | NULL   |      | BTREE      |         |               |
| event_summary |          1 | event_summary_last_seen_idx |            1 | last_seen              | A         |           0 |     NULL | NULL   |      | BTREE      |         |               |
+---------------+------------+-----------------------------+--------------+------------------------+-----------+-------------+----------+--------+------+------------+---------+---------------+
```