### PR TITLE
ZEN-16442 - Replace event_summary indexes, Add metrics for debugging

### DIFF
--- a/core/src/main/java/org/zenoss/zep/Counters.java
+++ b/core/src/main/java/org/zenoss/zep/Counters.java
@@ -1,0 +1,28 @@
+package org.zenoss.zep;
+
+public interface Counters {
+
+    long getArchivedEventCount();
+
+    long getAgedEventCount();
+
+    long getClearedEventCount();
+
+    long getDedupedEventCount();
+
+    long getDroppedEventCount();
+
+    long getProcessedEventCount();
+
+    void addToAgedEventCount(long delta);
+
+    void addToArchivedEventCount(long delta);
+
+    void addToClearedEventCount(long delta);
+
+    void addToDedupedEventCount(long delta);
+
+    void addToDroppedEventCount(long delta);
+
+    void addToProcessedEventCount(long delta);
+}

--- a/core/src/main/java/org/zenoss/zep/StatisticsService.java
+++ b/core/src/main/java/org/zenoss/zep/StatisticsService.java
@@ -13,12 +13,6 @@ import javax.management.DynamicMBean;
 
 public interface StatisticsService extends ZepMXBean, DynamicMBean {
 
-    public void addToProcessedEventCount(long delta);
-    public void addToDedupedEventCount(long delta);
-    public void addToDroppedEventCount(long delta);
-    public void addToClearedEventCount(long delta);
-    public void addToArchivedEventCount(long delta);
-    public void addToAgedEventCount(long delta);
 
     public String getAttributeDescription(String attributeName);
 

--- a/core/src/main/java/org/zenoss/zep/dao/impl/EventArchiveDaoImpl.java
+++ b/core/src/main/java/org/zenoss/zep/dao/impl/EventArchiveDaoImpl.java
@@ -10,6 +10,7 @@
 
 package org.zenoss.zep.dao.impl;
 
+import com.codahale.metrics.annotation.Timed;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.jdbc.core.simple.SimpleJdbcOperations;
@@ -81,6 +82,7 @@ public class EventArchiveDaoImpl implements EventArchiveDao {
 
     @Override
     @TransactionalRollbackAllExceptions
+    @Timed
     public String create(Event event, EventPreCreateContext context) throws ZepException {
         if (!ZepConstants.CLOSED_STATUSES.contains(event.getStatus())) {
             throw new ZepException("Invalid status for event in event archive: " + event.getStatus());
@@ -107,6 +109,7 @@ public class EventArchiveDaoImpl implements EventArchiveDao {
 
     @Override
     @TransactionalReadOnly
+    @Timed
     public EventSummary findByUuid(String uuid) throws ZepException {
         final Map<String,Object> fields = Collections.singletonMap(COLUMN_UUID, uuidConverter.toDatabaseType(uuid));
         List<EventSummary> summaries = this.template.query("SELECT * FROM event_archive WHERE uuid=:uuid",
@@ -117,6 +120,7 @@ public class EventArchiveDaoImpl implements EventArchiveDao {
     @Override
     @TransactionalReadOnly
     @Deprecated
+    @Timed
     /** @deprecated use {@link #findByKey(Collection) instead}. */
     public List<EventSummary> findByUuids(List<String> uuids)
             throws ZepException {
@@ -129,6 +133,7 @@ public class EventArchiveDaoImpl implements EventArchiveDao {
 
     @Override
     @TransactionalReadOnly
+    @Timed
     public List<EventSummary> findByKey(Collection<EventSummary> toLookup) throws ZepException {
         ArrayList<Object> fields = new ArrayList<Object>(toLookup.size() * 2);
         StringBuilder sql = new StringBuilder();
@@ -148,6 +153,7 @@ public class EventArchiveDaoImpl implements EventArchiveDao {
 
     @Override
     @TransactionalReadOnly
+    @Timed
     public EventBatch listBatch(EventBatchParams batchParams, long maxUpdateTime, int limit) throws ZepException {
         return this.eventDaoHelper.listBatch(this.template, TABLE_EVENT_ARCHIVE, this.partitioner, batchParams, maxUpdateTime, limit,
                 new EventArchiveRowMapper(eventDaoHelper, databaseCompatibility));
@@ -155,6 +161,7 @@ public class EventArchiveDaoImpl implements EventArchiveDao {
 
     @Override
     @TransactionalRollbackAllExceptions
+    @Timed
     public void initializePartitions() throws ZepException {
         this.partitioner.createPartitions(
                 this.partitionTableConfig.getInitialPastPartitions(),
@@ -162,6 +169,7 @@ public class EventArchiveDaoImpl implements EventArchiveDao {
     }
 
     @Override
+    @Timed
     public long getPartitionIntervalInMs() {
         return this.partitionTableConfig.getPartitionUnit().toMillis(
                 this.partitionTableConfig.getPartitionDuration());
@@ -169,12 +177,14 @@ public class EventArchiveDaoImpl implements EventArchiveDao {
 
     @Override
     @TransactionalRollbackAllExceptions
+    @Timed
     public int addNote(String uuid, EventNote note) throws ZepException {
         return this.eventDaoHelper.addNote(TABLE_EVENT_ARCHIVE, uuid, note, template);
     }
 
     @Override
     @TransactionalRollbackAllExceptions
+    @Timed
     public int updateDetails(String uuid, EventDetailSet details)
             throws ZepException {
         return this.eventDaoHelper.updateDetails(TABLE_EVENT_ARCHIVE, uuid, details.getDetailsList(), template);
@@ -182,6 +192,7 @@ public class EventArchiveDaoImpl implements EventArchiveDao {
 
     @Override
     @TransactionalRollbackAllExceptions
+    @Timed
     public void purge(int duration, TimeUnit unit) throws ZepException {
         this.partitioner.pruneAndCreatePartitions(duration,
                 unit,
@@ -191,6 +202,7 @@ public class EventArchiveDaoImpl implements EventArchiveDao {
 
     @Override
     @TransactionalRollbackAllExceptions
+    @Timed
     public void importEvent(EventSummary eventSummary) throws ZepException {
         if (!ZepConstants.CLOSED_STATUSES.contains(eventSummary.getStatus())) {
             throw new ZepException("Invalid status for event in event archive: " + eventSummary.getStatus());

--- a/core/src/main/java/org/zenoss/zep/dao/impl/EventSummaryDaoImpl.java
+++ b/core/src/main/java/org/zenoss/zep/dao/impl/EventSummaryDaoImpl.java
@@ -208,6 +208,7 @@ public class EventSummaryDaoImpl implements EventSummaryDao {
         } catch (Exception e) {
             throw new ZepException(e);
         }
+        metricRegistry.histogram(getClass().getName() + ".createOldSummaryListSize").update(oldSummaryList.size());
         final String uuid;
         if (!oldSummaryList.isEmpty()) {
             final Event finalEvent = event;

--- a/core/src/main/java/org/zenoss/zep/impl/AbstractQueueListener.java
+++ b/core/src/main/java/org/zenoss/zep/impl/AbstractQueueListener.java
@@ -10,8 +10,10 @@
 
 package org.zenoss.zep.impl;
 
+import com.codahale.metrics.MetricRegistry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.TransientDataAccessException;
 import org.zenoss.amqp.AmqpException;
 import org.zenoss.amqp.Consumer;
@@ -29,51 +31,87 @@ public abstract class AbstractQueueListener extends QueueListener {
 
     protected ExecutorService executorService;
 
+    @Autowired
+    protected MetricRegistry metricRegistry;
+
+    private final String ackMessageTimerName     = this.getClass().getName() + ".ackMessage";
+    private final String handleMessageTimerName  = this.getClass().getName() + ".handleMessage";
+    private final String receiveMessageTimerName = this.getClass().getName() + ".receiveMessage";
+    private final String rejectMessageTimerName  = this.getClass().getName() + ".rejectMessage";
+
     protected abstract String getQueueIdentifier();
+
 
     public void setExecutorService(ExecutorService executorService) {
         this.executorService = executorService;
     }
-
-    protected void rejectMessage(Consumer<?> consumer, Message<?> message, boolean requeue) {
+    protected void rejectMessage(final Consumer<?> consumer, final Message<?> message, final boolean requeue) {
         try {
-            consumer.rejectMessage(message, requeue);
-        } catch (AmqpException e) {
-            logger.warn("Failed rejecting message", e);
+            metricRegistry.timer(rejectMessageTimerName).time(new Callable<Object>() {
+                @Override
+                public Object call() throws Exception {
+                    try {
+                        consumer.rejectMessage(message, requeue);
+                    } catch (AmqpException e) {
+                        logger.warn("Failed rejecting message", e);
+                    }
+                    return null;
+                }
+            });
+        } catch (Exception e) {
+            throw new RuntimeException(e);
         }
     }
 
     @Override
     protected void receive(final Message<com.google.protobuf.Message> message,
             final Consumer<com.google.protobuf.Message> consumer) throws Exception {
-        this.executorService.submit(new Runnable() {
+        metricRegistry.timer(receiveMessageTimerName).time(new Callable<Object>() {
             @Override
-            public void run() {
-                try {
-                    DaoUtils.deadlockRetry(new Callable<Object>() {
-                        @Override
-                        public Object call() throws Exception {
-                            handle(message.getBody());
-                            return null;
-                        }
-                    });
-                    consumer.ackMessage(message);
-                } catch (Exception e) {
-                    if (ZepUtils.isExceptionOfType(e, TransientDataAccessException.class)) {
+            public Object call() throws Exception {
+                AbstractQueueListener.this.executorService.submit(new Runnable() {
+                    @Override
+                    public void run() {
+                        try {
+                            DaoUtils.deadlockRetry(new Callable<Object>() {
+                                @Override
+                                public Object call() throws Exception {
+                                    metricRegistry.timer(handleMessageTimerName).time(new Callable<Object>() {
+                                        @Override
+                                        public Object call() throws Exception {
+                                            handle(message.getBody());
+                                            return null;
+                                        }
+                                    });
+                                    return null;
+                                }
+                            });
+                            metricRegistry.timer(ackMessageTimerName).time(new Callable<Object>() {
+                                @Override
+                                public Object call() throws Exception {
+                                    consumer.ackMessage(message);
+                                    return null;
+                                }
+                            });
+                        } catch (Exception e) {
+                            if (ZepUtils.isExceptionOfType(e, TransientDataAccessException.class)) {
                         /* Re-queue the message if we get a temporary database failure */
-                        logger.debug("Transient database exception", e);
-                        logger.debug("Re-queueing message due to transient failure: {}", message);
-                        rejectMessage(consumer, message, true);
-                    } else if (!message.getEnvelope().isRedeliver()) {
+                                logger.debug("Transient database exception", e);
+                                logger.debug("Re-queueing message due to transient failure: {}", message);
+                                rejectMessage(consumer, message, true);
+                            } else if (!message.getEnvelope().isRedeliver()) {
                         /* Attempt one redelivery of the message */
-                        logger.debug("First failure processing message: " + message, e);
-                        rejectMessage(consumer, message, true);
-                    } else {
+                                logger.debug("First failure processing message: " + message, e);
+                                rejectMessage(consumer, message, true);
+                            } else {
                         /* TODO: Dead letter queue or other safety net? */
-                        logger.warn("Failed processing message: " + message, e);
-                        rejectMessage(consumer, message, false);
+                                logger.warn("Failed processing message: " + message, e);
+                                rejectMessage(consumer, message, false);
+                            }
+                        }
                     }
-                }
+                });
+                return null;
             }
         });
     }

--- a/core/src/main/java/org/zenoss/zep/impl/CountersImpl.java
+++ b/core/src/main/java/org/zenoss/zep/impl/CountersImpl.java
@@ -1,0 +1,78 @@
+package org.zenoss.zep.impl;
+
+import org.zenoss.zep.Counters;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+
+public class CountersImpl implements Counters {
+
+    @Override
+    public long getArchivedEventCount() {
+        return archivedEvents.get();
+    }
+
+
+    @Override
+    public long getAgedEventCount() {
+        return agedEvents.get();
+    }
+
+    @Override
+    public long getClearedEventCount() {
+        return clearedEvents.get();
+    }
+
+    @Override
+    public long getDedupedEventCount() {
+        return dedupedEvents.get();
+    }
+
+    @Override
+    public long getDroppedEventCount() {
+        return droppedEvents.get();
+    }
+
+    @Override
+    public long getProcessedEventCount() {
+        return processedEvents.get();
+    }
+
+    @Override
+    public void addToAgedEventCount(long delta) {
+        agedEvents.addAndGet(delta);
+    }
+
+    @Override
+    public void addToArchivedEventCount(long delta) {
+        archivedEvents.addAndGet(delta);
+    }
+
+    @Override
+    public void addToClearedEventCount(long delta) {
+        clearedEvents.addAndGet(delta);
+    }
+
+    @Override
+    public void addToDedupedEventCount(long delta) {
+        dedupedEvents.addAndGet(delta);
+    }
+
+    @Override
+    public void addToDroppedEventCount(long delta) {
+        droppedEvents.addAndGet(delta);
+    }
+
+    @Override
+    public void addToProcessedEventCount(long delta) {
+        processedEvents.addAndGet(delta);
+    }
+
+    private final AtomicLong agedEvents = new AtomicLong();
+    private final AtomicLong archivedEvents = new AtomicLong();
+    private final AtomicLong clearedEvents = new AtomicLong();
+    private final AtomicLong dedupedEvents = new AtomicLong();
+    private final AtomicLong droppedEvents = new AtomicLong();
+    private final AtomicLong processedEvents = new AtomicLong();
+
+}

--- a/core/src/main/java/org/zenoss/zep/impl/EventFlappingPlugin.java
+++ b/core/src/main/java/org/zenoss/zep/impl/EventFlappingPlugin.java
@@ -10,6 +10,7 @@
 
 package org.zenoss.zep.impl;
 
+import com.codahale.metrics.annotation.Timed;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -315,6 +316,7 @@ public class EventFlappingPlugin extends EventPreCreatePlugin implements Applica
     }
 
     @Override
+    @Timed
     public Event processEvent(Event event, EventPreCreateContext context) throws ZepException {
         if (enabled) {
             final long startTime = System.currentTimeMillis();

--- a/core/src/main/java/org/zenoss/zep/impl/EventProcessorImpl.java
+++ b/core/src/main/java/org/zenoss/zep/impl/EventProcessorImpl.java
@@ -10,6 +10,7 @@
 
 package org.zenoss.zep.impl;
 
+import com.codahale.metrics.annotation.Timed;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.dao.DuplicateKeyException;
@@ -17,10 +18,7 @@ import org.zenoss.protobufs.zep.Zep.Event;
 import org.zenoss.protobufs.zep.Zep.EventStatus;
 import org.zenoss.protobufs.zep.Zep.EventSummary;
 import org.zenoss.protobufs.zep.Zep.ZepRawEvent;
-import org.zenoss.zep.EventProcessor;
-import org.zenoss.zep.PluginService;
-import org.zenoss.zep.StatisticsService;
-import org.zenoss.zep.ZepException;
+import org.zenoss.zep.*;
 import org.zenoss.zep.dao.EventSummaryDao;
 import org.zenoss.zep.plugins.EventPostCreateContext;
 import org.zenoss.zep.plugins.EventPostCreatePlugin;
@@ -41,7 +39,7 @@ public class EventProcessorImpl implements EventProcessor {
 
     private EventSummaryDao eventSummaryDao;
 
-    private StatisticsService statisticsService;
+    private Counters counters;
 
     public void setEventSummaryDao(EventSummaryDao eventSummaryDao) {
         this.eventSummaryDao = eventSummaryDao;
@@ -57,8 +55,8 @@ public class EventProcessorImpl implements EventProcessor {
         this.pluginService = pluginService;
     }
 
-    public void setStatisticsService(final StatisticsService statisticsService) {
-        this.statisticsService = statisticsService;
+    public void setCounters(Counters counters) {
+        this.counters = counters;
     }
 
     private static Event eventFromRawEvent(ZepRawEvent zepRawEvent) {
@@ -71,23 +69,24 @@ public class EventProcessorImpl implements EventProcessor {
     }
 
     @Override
+    @Timed
     public void processEvent(ZepRawEvent zepRawEvent) throws ZepException {
         logger.debug("processEvent: event={}", zepRawEvent);
-        statisticsService.addToProcessedEventCount(1);
+        counters.addToProcessedEventCount(1);
 
         if (zepRawEvent.getEvent().getStatus() == EventStatus.STATUS_DROPPED) {
             logger.debug("Event dropped: {}", zepRawEvent);
-            statisticsService.addToDroppedEventCount(1);
+            counters.addToDroppedEventCount(1);
             return;
         } else if (zepRawEvent.getEvent().getUuid().isEmpty()) {
             logger.error("Could not process event, has no uuid: {}",
                     zepRawEvent);
-            statisticsService.addToDroppedEventCount(1);
+            counters.addToDroppedEventCount(1);
             return;
         } else if (!zepRawEvent.getEvent().hasCreatedTime()) {
             logger.error("Could not process event, has no created_time: {}",
                     zepRawEvent);
-            statisticsService.addToDroppedEventCount(1);
+            counters.addToDroppedEventCount(1);
             return;
         }
 
@@ -98,7 +97,7 @@ public class EventProcessorImpl implements EventProcessor {
             Event modified = plugin.processEvent(event, ctx);
             if (modified != null && modified.getStatus() == EventStatus.STATUS_DROPPED) {
                 logger.debug("Event dropped by {}", plugin.getId());
-                statisticsService.addToDroppedEventCount(1);
+                counters.addToDroppedEventCount(1);
                 return;
             }
 
@@ -115,7 +114,11 @@ public class EventProcessorImpl implements EventProcessor {
             // Catch DuplicateKeyException and retry creating the event. Otherwise, the failure
             // will propagate to the AMQP consumer, the message will be rejected (and re-queued),
             // leading to unnecessary load on the AMQP server re-queueing/re-delivering the event.
-            logger.debug("DuplicateKeyException - retrying event: {}", event);
+            if (logger.isDebugEnabled()) {
+                logger.info("DuplicateKeyException - retrying event: {}", event);
+            } else {
+                logger.info("DuplicateKeyException - retrying event: {}", event.getUuid());
+            }
             uuid = this.eventSummaryDao.create(event, ctx);
         }
 

--- a/core/src/main/java/org/zenoss/zep/impl/EventPublisherImpl.java
+++ b/core/src/main/java/org/zenoss/zep/impl/EventPublisherImpl.java
@@ -10,6 +10,7 @@
 
 package org.zenoss.zep.impl;
 
+import com.codahale.metrics.annotation.Timed;
 import org.zenoss.amqp.AmqpConnectionManager;
 import org.zenoss.amqp.AmqpException;
 import org.zenoss.amqp.ExchangeConfiguration;
@@ -37,6 +38,7 @@ public class EventPublisherImpl implements EventPublisher {
     }
 
     @Override
+    @Timed
     public void publishEvent(Event rawEvent) throws ZepException {
         try {
             this.connectionManager.publish(exchangeConfiguration, createRoutingKey(rawEvent), rawEvent);

--- a/core/src/main/java/org/zenoss/zep/impl/StatisticsServiceImpl.java
+++ b/core/src/main/java/org/zenoss/zep/impl/StatisticsServiceImpl.java
@@ -14,6 +14,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.zenoss.protobufs.zep.Zep.EventSeverity;
 import org.zenoss.protobufs.zep.Zep.ZepConfig;
+import org.zenoss.zep.Counters;
 import org.zenoss.zep.ZepException;
 import org.zenoss.zep.ZepMXBean;
 import org.zenoss.zep.StatisticsService;
@@ -27,7 +28,6 @@ import javax.management.StandardMBean;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicLong;
 
 public class StatisticsServiceImpl extends StandardMBean implements StatisticsService {
 
@@ -52,19 +52,13 @@ public class StatisticsServiceImpl extends StandardMBean implements StatisticsSe
         attributeDescriptions.put("ArchiveIndexDocCount", "archive index doc count");
     }
 
+    private Counters counters;
     private ConfigDao configDao;
     private EventSummaryDao eventSummaryDao;
     private EventIndexDao eventSummaryIndexDao;
     private EventIndexDao eventArchiveIndexDao;
     private EventIndexQueueDao eventSummaryIndexQueueDao;
     private EventIndexQueueDao eventArchiveIndexQueueDao;
-
-    private AtomicLong processedEventCount = new AtomicLong();
-    private AtomicLong dedupedEventCount = new AtomicLong();
-    private AtomicLong droppedEventCount = new AtomicLong();
-    private AtomicLong clearedEventCount = new AtomicLong();
-    private AtomicLong archivedEventCount = new AtomicLong();
-    private AtomicLong agedEventCount = new AtomicLong();
 
     public StatisticsServiceImpl() {
         super(ZepMXBean.class, true);
@@ -78,6 +72,10 @@ public class StatisticsServiceImpl extends StandardMBean implements StatisticsSe
     @Override
     public String getAttributeDescription(String name) {
         return attributeDescriptions.get(name);
+    }
+
+    public void setCounters(final Counters counters) {
+        this.counters = counters;
     }
 
     public void setConfigDao(final ConfigDao configDao) {
@@ -105,63 +103,33 @@ public class StatisticsServiceImpl extends StandardMBean implements StatisticsSe
     }
 
     @Override
-    public long getProcessedEventCount() {
-        return processedEventCount.get();
-    }
-
-    @Override
-    public void addToProcessedEventCount(long delta) {
-        processedEventCount.getAndAdd(delta);
-    }
-
-    @Override
-    public long getDedupedEventCount() {
-        return dedupedEventCount.get();
-    }
-
-    @Override
-    public void addToDedupedEventCount(long delta) {
-        dedupedEventCount.getAndAdd(delta);
-    }
-
-    @Override
-    public long getDroppedEventCount() {
-        return droppedEventCount.get();
-    }
-
-    @Override
-    public void addToDroppedEventCount(long delta) {
-        droppedEventCount.getAndAdd(delta);
-    }
-
-    @Override
-    public long getClearedEventCount() {
-        return clearedEventCount.get();
-    }
-
-    @Override
-    public void addToClearedEventCount(long delta) {
-        clearedEventCount.getAndAdd(delta);
+    public long getAgedEventCount() {
+        return counters.getAgedEventCount();
     }
 
     @Override
     public long getArchivedEventCount() {
-        return archivedEventCount.get();
+        return counters.getArchivedEventCount();
     }
 
     @Override
-    public void addToArchivedEventCount(long delta) {
-        archivedEventCount.getAndAdd(delta);
+    public long getClearedEventCount() {
+        return counters.getClearedEventCount();
     }
 
     @Override
-    public long getAgedEventCount() {
-        return agedEventCount.get();
+    public long getDedupedEventCount() {
+        return counters.getDedupedEventCount();
     }
 
     @Override
-    public void addToAgedEventCount(long delta) {
-        agedEventCount.getAndAdd(delta);
+    public long getDroppedEventCount() {
+        return counters.getDroppedEventCount();
+    }
+
+    @Override
+    public long getProcessedEventCount() {
+        return counters.getProcessedEventCount();
     }
 
     @Override
@@ -227,5 +195,4 @@ public class StatisticsServiceImpl extends StandardMBean implements StatisticsSe
     public long getArchiveIndexDocCount() {
         return getNumDocs(eventArchiveIndexDao);
     }
-
 }

--- a/core/src/main/java/org/zenoss/zep/index/impl/EventIndexerImpl.java
+++ b/core/src/main/java/org/zenoss/zep/index/impl/EventIndexerImpl.java
@@ -158,15 +158,16 @@ public class EventIndexerImpl implements EventIndexer, ApplicationListener<ZepCo
 
     @Override
     @Timed
-    public synchronized int indexFully() throws ZepException {
+    public int indexFully() throws ZepException {
         int totalIndexed = 0;
         final long now = System.currentTimeMillis();
         int numIndexed;
-        do {
-            numIndexed = doIndex(now);
-            totalIndexed += numIndexed;
-        } while (numIndexed > 0);
-
+        synchronized (this) {
+            do {
+                numIndexed = doIndex(now);
+                totalIndexed += numIndexed;
+            } while (numIndexed > 0);
+        }
         return totalIndexed;
     }
 

--- a/core/src/main/resources/zep-config-daos.xml
+++ b/core/src/main/resources/zep-config-daos.xml
@@ -52,7 +52,7 @@
         <property name="uuidGenerator" ref="uuidGenerator"/>
         <property name="databaseCompatibility" ref="databaseCompatibility"/>
         <property name="nestedTransactionService" ref="nestedTransactionService"/>
-        <property name="statisticsService" ref="statisticsService"/>
+        <property name="counters" ref="counters"/>
     </bean>
     <bean id="eventArchiveDao" class="org.zenoss.zep.dao.impl.EventArchiveDaoImpl">
         <constructor-arg index="0" ref="dataSource"/>

--- a/core/src/main/resources/zep-config.xml
+++ b/core/src/main/resources/zep-config.xml
@@ -52,7 +52,7 @@
     <bean id="eventProcessor" class="org.zenoss.zep.impl.EventProcessorImpl">
         <property name="pluginService" ref="pluginService"/>
         <property name="eventSummaryDao" ref="eventSummaryDao"/>
-        <property name="statisticsService" ref="statisticsService"/>
+        <property name="counters" ref="counters"/>
     </bean>
 
     <bean id="eventPublisher" class="org.zenoss.zep.impl.EventPublisherImpl">
@@ -193,7 +193,10 @@
         </property>
     </bean>
 
+    <bean id="counters" class="org.zenoss.zep.impl.CountersImpl" />
+
     <bean id="statisticsService" class="org.zenoss.zep.impl.StatisticsServiceImpl">
+        <property name="counters" ref="counters"/>
         <property name="configDao" ref="configDao"/>
         <property name="eventSummaryDao" ref="eventSummaryDao"/>
         <property name="eventSummaryIndexDao" ref="eventSummaryIndexDao"/>

--- a/core/src/main/sql/mysql/007.sql
+++ b/core/src/main/sql/mysql/007.sql
@@ -1,0 +1,29 @@
+-- Copyright (C) 2015, Zenoss Inc.  All Rights Reserved.
+
+--
+-- Adds an index for faster aging of events from summary to archive.
+--
+
+DROP PROCEDURE IF EXISTS drop_index_if_exists;
+DELIMITER $$
+CREATE PROCEDURE drop_index_if_exists(IN tname VARCHAR(64), IN idx_name VARCHAR(64))
+BEGIN
+  IF EXISTS(SELECT 1 FROM INFORMATION_SCHEMA.STATISTICS WHERE table_schema = DATABASE()
+            AND UPPER(table_name) = tname AND UPPER(index_name) = idx_name)
+  THEN
+    SET @drop_sql = CONCAT('DROP INDEX ',idx_name,' ON ',tname,';');
+    PREPARE stmt FROM @drop_sql;
+    EXECUTE stmt;
+    DEALLOCATE PREPARE stmt;
+  END IF;
+END
+$$
+DELIMITER ;
+
+CALL drop_index_if_exists('event_summary','event_summary_last_seen');
+CALL drop_index_if_exists('event_summary','event_summary_last_seen_idx');
+CREATE INDEX event_summary_last_seen_idx ON event_summary(last_seen);
+
+DROP PROCEDURE IF EXISTS drop_index_if_exists;
+
+INSERT INTO schema_version (version, installed_time) VALUES(7, NOW());

--- a/core/src/main/sql/mysql/007.sql
+++ b/core/src/main/sql/mysql/007.sql
@@ -20,7 +20,14 @@ END
 $$
 DELIMITER ;
 
+-- If we don't delete these two, the query planner sometimes chooses to use one
+-- of them when it would be better to use event_summary_last_seen_idx.
+CALL drop_index_if_exists('event_summary','event_summary_age_idx');
+CALL drop_index_if_exists('event_summary','event_summary_archive_idx');
+
+-- At one of our customers, this index was created manually.
 CALL drop_index_if_exists('event_summary','event_summary_last_seen');
+
 CALL drop_index_if_exists('event_summary','event_summary_last_seen_idx');
 CREATE INDEX event_summary_last_seen_idx ON event_summary(last_seen);
 

--- a/core/src/main/sql/postgresql/003.sql
+++ b/core/src/main/sql/postgresql/003.sql
@@ -1,0 +1,8 @@
+--
+-- Adds an index for faster aging of events from summary to archive.
+--
+
+DROP INDEX IF EXISTS event_summary_last_seen;
+CREATE INDEX event_summary_last_seen_idx ON event_summary(last_seen);
+
+INSERT INTO schema_version (version, installed_time) VALUES(3, NOW());

--- a/core/src/main/sql/postgresql/003.sql
+++ b/core/src/main/sql/postgresql/003.sql
@@ -2,6 +2,9 @@
 -- Adds an index for faster aging of events from summary to archive.
 --
 
+DROP INDEX IF EXISTS event_summary_age_idx;
+DROP INDEX IF EXISTS event_summary_archive_idx;
+
 DROP INDEX IF EXISTS event_summary_last_seen;
 CREATE INDEX event_summary_last_seen_idx ON event_summary(last_seen);
 

--- a/core/src/test/java/org/zenoss/zep/impl/EventProcessorImplTest.java
+++ b/core/src/test/java/org/zenoss/zep/impl/EventProcessorImplTest.java
@@ -16,8 +16,8 @@ import org.zenoss.amqp.AmqpException;
 import org.zenoss.protobufs.zep.Zep.Event;
 import org.zenoss.protobufs.zep.Zep.EventSummary;
 import org.zenoss.protobufs.zep.Zep.ZepRawEvent;
+import org.zenoss.zep.Counters;
 import org.zenoss.zep.PluginService;
-import org.zenoss.zep.StatisticsService;
 import org.zenoss.zep.ZepException;
 import org.zenoss.zep.dao.EventSummaryDao;
 import org.zenoss.zep.plugins.EventPostCreateContext;
@@ -72,7 +72,7 @@ public class EventProcessorImplTest {
             AmqpException {
         PluginService pluginService = createMock(PluginService.class);
         EventSummaryDao eventSummaryDao = createMock(EventSummaryDao.class);
-        StatisticsService statisticsService = createMock(StatisticsService.class);
+        Counters counters = createMock(Counters.class);
         SamplePostPlugin postPlugin = new SamplePostPlugin();
 
         Capture<Event> transformedEvent = new Capture<Event>();
@@ -96,7 +96,7 @@ public class EventProcessorImplTest {
         EventProcessorImpl eventProcessor = new EventProcessorImpl();
         eventProcessor.setPluginService(pluginService);
         eventProcessor.setEventSummaryDao(eventSummaryDao);
-        eventProcessor.setStatisticsService(statisticsService);
+        eventProcessor.setCounters(counters);
 
         Event.Builder eventBuilder = Event.newBuilder();
         eventBuilder.setUuid(UUID.randomUUID().toString());
@@ -120,7 +120,7 @@ public class EventProcessorImplTest {
             IOException, AmqpException {
         PluginService pluginService = createMock(PluginService.class);
         EventSummaryDao eventSummaryDao = createMock(EventSummaryDao.class);
-        StatisticsService statisticsService = createMock(StatisticsService.class);
+        Counters counters = createMock(Counters.class);
 
         Capture<Event> transformedEvent = new Capture<Event>();
         Capture<EventPreCreateContext> transformedContext = new Capture<EventPreCreateContext>();
@@ -138,7 +138,7 @@ public class EventProcessorImplTest {
         EventProcessorImpl eventProcessor = new EventProcessorImpl();
         eventProcessor.setPluginService(pluginService);
         eventProcessor.setEventSummaryDao(eventSummaryDao);
-        eventProcessor.setStatisticsService(statisticsService);
+        eventProcessor.setCounters(counters);
 
         Event.Builder eventBuilder = Event.newBuilder();
         eventBuilder.setUuid(UUID.randomUUID().toString());


### PR DESCRIPTION
PLEASE REVIEW, BUT DO NOT MERGE YET. (Just add a comment)

I've only tested that the index gets created automatically on a fresh (zendev) install. I did not test an upgrade.

```bash
MariaDB [zenoss_zep]> show index from event_summary;
+---------------+------------+-----------------------------+--------------+------------------------+-----------+-------------+----------+--------+------+------------+---------+---------------+
| Table         | Non_unique | Key_name                    | Seq_in_index | Column_name            | Collation | Cardinality | Sub_part | Packed | Null | Index_type | Comment | Index_comment |
+---------------+------------+-----------------------------+--------------+------------------------+-----------+-------------+----------+--------+------+------------+---------+---------------+
| event_summary |          0 | PRIMARY                     |            1 | uuid                   | A         |           0 |     NULL | NULL   |      | BTREE      |         |               |
| event_summary |          0 | fingerprint_hash            |            1 | fingerprint_hash       | A         |           0 |     NULL | NULL   |      | BTREE      |         |               |
| event_summary |          1 | element_uuid                |            1 | element_uuid           | A         |           0 |     NULL | NULL   | YES  | BTREE      |         |               |
| event_summary |          1 | element_uuid                |            2 | element_type_id        | A         |           0 |     NULL | NULL   | YES  | BTREE      |         |               |
| event_summary |          1 | element_uuid                |            3 | element_identifier     | A         |           0 |     NULL | NULL   |      | BTREE      |         |               |
| event_summary |          1 | element_sub_uuid            |            1 | element_sub_uuid       | A         |           0 |     NULL | NULL   | YES  | BTREE      |         |               |
| event_summary |          1 | element_sub_uuid            |            2 | element_sub_type_id    | A         |           0 |     NULL | NULL   | YES  | BTREE      |         |               |
| event_summary |          1 | element_sub_uuid            |            3 | element_sub_identifier | A         |           0 |     NULL | NULL   | YES  | BTREE      |         |               |
| event_summary |          1 | event_summary_clear_idx     |            1 | clear_fingerprint_hash | A         |           0 |     NULL | NULL   | YES  | BTREE      |         |               |
| event_summary |          1 | event_summary_clear_idx     |            2 | status_id              | A         |           0 |     NULL | NULL   |      | BTREE      |         |               |
| event_summary |          1 | event_summary_clear_idx     |            3 | last_seen              | A         |           0 |     NULL | NULL   |      | BTREE      |         |               |
| event_summary |          1 | event_summary_last_seen_idx |            1 | last_seen              | A         |           0 |     NULL | NULL   |      | BTREE      |         |               |
+---------------+------------+-----------------------------+--------------+------------------------+-----------+-------------+----------+--------+------+------------+---------+---------------+
```

The introduction of the Counters interface was necessary to break cycles going through StatisticsServiceImpl. Trying to simply add Timed annotations resulted in spring framework errors like the following at startup...

> Error creating bean with name 'eventStoreDao' defined in class path resource [zep-config-daos.xml]: Cannot resolve reference to bean 'eventSummaryDao' while setting bean property 'eventSummaryDao'; nested exception is org.springframework.beans.factory.BeanCurrentlyInCreationException: Error creating bean with name 'eventSummaryDao': Bean with name 'eventSummaryDao' has been injected into other beans [statisticsService,eventSummaryIndexDao,luceneEventSummaryIndexBackend] in its raw version as part of a circular reference, but has eventually been wrapped. This means that said other beans do not use the final version of the bean. This is often the result of over-eager type matching - consider using 'getBeanNamesOfType' with the 'allowEagerInit' flag turned off, for example.