### PR TITLE
Feature/zen 17356

### DIFF
--- a/core/src/main/java/org/zenoss/zep/index/impl/EventIndexerImpl.java
+++ b/core/src/main/java/org/zenoss/zep/index/impl/EventIndexerImpl.java
@@ -308,7 +308,12 @@ public class EventIndexerImpl implements EventIndexer, ApplicationListener<ZepCo
                 indexDao.commit();
                 if (calledStartBatch.get()) {
                     for (EventPostIndexPlugin plugin : plugins) {
-                        plugin.endBatch(context);
+                        try {
+                            plugin.endBatch(context);
+                        } catch (Exception e) {
+                            // Post-processing plug-in failures are not fatal errors.
+                            logger.warn("Failed to finish batch for post-processing plug-in.", e);
+                        }
                     }
                 }
             }

--- a/core/src/main/java/org/zenoss/zep/index/impl/EventIndexerImpl.java
+++ b/core/src/main/java/org/zenoss/zep/index/impl/EventIndexerImpl.java
@@ -305,12 +305,12 @@ public class EventIndexerImpl implements EventIndexer, ApplicationListener<ZepCo
 
             @Override
             public void handleComplete() throws Exception {
+                indexDao.commit();
                 if (calledStartBatch.get()) {
                     for (EventPostIndexPlugin plugin : plugins) {
                         plugin.endBatch(context);
                     }
                 }
-                indexDao.commit();
             }
         }, limit, throughTime);
 

--- a/core/src/main/java/org/zenoss/zep/index/impl/EventIndexerImpl.java
+++ b/core/src/main/java/org/zenoss/zep/index/impl/EventIndexerImpl.java
@@ -245,6 +245,11 @@ public class EventIndexerImpl implements EventIndexer, ApplicationListener<ZepCo
             }
 
             @Override
+            public int getIndexLimit() {
+                return limit;
+            }
+
+            @Override
             public Object getPluginState(EventPostIndexPlugin plugin) {
                 return pluginState.get(plugin);
             }

--- a/core/src/main/java/org/zenoss/zep/plugins/EventPostIndexContext.java
+++ b/core/src/main/java/org/zenoss/zep/plugins/EventPostIndexContext.java
@@ -19,7 +19,9 @@ public interface EventPostIndexContext {
      *
      * @return True if the event is in the event archive, false otherwise.
      */
-    public boolean isArchive();
+    boolean isArchive();
+
+    int getIndexLimit();
 
     Object getPluginState(EventPostIndexPlugin plugin);
 

--- a/core/src/main/java/org/zenoss/zep/plugins/EventPostIndexPlugin.java
+++ b/core/src/main/java/org/zenoss/zep/plugins/EventPostIndexPlugin.java
@@ -31,7 +31,9 @@ public abstract class EventPostIndexPlugin extends EventPlugin {
     public void preProcessEvents(Collection<EventSummary> eventSummaries, EventPostIndexContext context) throws ZepException {}
 
     /**
-     * Processes the eventSummary.
+     * Processes the eventSummary. At this time, the index has not yet been
+     * committed, so any process that will immediately rely on a consistent
+     * index state should wait until the batch is ended.
      * 
      * @param eventSummary The eventSummary to process.
      * @param context Context passed to EventPostIndexPlugin.
@@ -54,7 +56,9 @@ public abstract class EventPostIndexPlugin extends EventPlugin {
     /**
      * Called when the post index batch operation has completed. This should
      * perform any final operations for the plug-in and clean up any shared
-     * state initialized in {@link #startBatch(EventPostIndexContext)}.
+     * state initialized in {@link #startBatch(EventPostIndexContext)}. This
+     * method runs after the index has been committed, so can rely on the index
+     * to be consistent.
      *
      * @param context Context for the post-index plug-in.
      * @throws Exception If an exception occurs.


### PR DESCRIPTION
Changes the PostIndexPlugin contract to be clear about when exactly the index is committed. This prevents a race condition where a CLEAR event has been sent to the fanout queue and the index is being queried for the same entity, but the indexing commit has not yet been performed. Thus the clear event, when queried, will still return the original event.