### PR TITLE
ZEN-17382: Log external optimizations

### DIFF
--- a/core/src/main/java/org/zenoss/zep/dao/impl/DBMaintenanceServiceImpl.java
+++ b/core/src/main/java/org/zenoss/zep/dao/impl/DBMaintenanceServiceImpl.java
@@ -28,10 +28,8 @@ import org.zenoss.zep.ZepInstance;
 import org.zenoss.zep.dao.DBMaintenanceService;
 import org.zenoss.zep.dao.impl.compat.DatabaseCompatibility;
 import org.zenoss.zep.dao.impl.compat.DatabaseType;
-import org.zenoss.zep.dao.impl.DaoUtils;
 
 import javax.sql.DataSource;
-import java.io.IOException;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.sql.Statement;
@@ -241,19 +239,19 @@ public class DBMaintenanceServiceImpl implements DBMaintenanceService {
         final String tableToOptimize = "event_summary";
         // if we want to use percona's pt-online-schema-change to avoid locking the tables due to mysql optimize...
         //checks if external tool is available
-        if (this.useExternalTool && dbType == DatabaseType.MYSQL && DaoUtils.executeCommand("ls " + externalToolName) == 0) {
+        if (this.useExternalTool && dbType == DatabaseType.MYSQL && DaoUtils.executeCommand("ls " + externalToolName, null) == 0) {
             logger.info("Validating state of event_summary");
             this.validateEventSummaryState();
             logger.debug("Optimizing table: " + tableToOptimize + " via percona " + externalToolName);
             eventSummaryOptimizationTime.setStartTime();
 
-            String externalToolCommandPrefix = externalToolName + " --alter \"ENGINE=Innodb\" D=" + this.dbname + ",t=";
+            String externalToolCommandPrefix = externalToolName + " --statistics --alter \"ENGINE=Innodb\" D=" + this.dbname + ",t=";
             String externalToolCommandSuffix = "";
             if (System.getenv("USE_ZENDS") != null && Integer.parseInt(System.getenv("USE_ZENDS").trim()) == 1) {
                 externalToolCommandSuffix = " --defaults-file=/opt/zends/etc/zends.cnf";
             }
             externalToolCommandSuffix += " " + this.externalToolOptions + " --alter-foreign-keys-method=drop_swap --host=" + this.hostname + " --port=" + this.port + " --user=" + this.username + " --password=" + this.password + " --execute";
-            int return_code = DaoUtils.executeCommand(externalToolCommandPrefix + tableToOptimize + externalToolCommandSuffix);
+            int return_code = DaoUtils.executeCommand(externalToolCommandPrefix + tableToOptimize + externalToolCommandSuffix, "-OPTIMIZE");
             if (return_code != 0) {
                 logger.error("External tool failed on: " + tableToOptimize + ". Therefore, table:" + tableToOptimize + "will not be optimized.");
             } else {


### PR DESCRIPTION
To better troubleshoot issues with DB optimizations using external
tools, this change will log (to ZEP's normal log) the output of an external
tool as it runs.

Sample output:
```
2015-08-26T19:33:47.072 [ZEP_DATABASE_MAINTENANCE] INFO  org.zenoss.zep.dao.impl.DaoUtils - Running command: ls /var/zenoss/percona/bin/pt-online-schema-change
2015-08-26T19:33:47.082 [ZEP_DATABASE_MAINTENANCE] INFO  org.zenoss.zep.dao.impl.DaoUtils - Command ran successfully (return code: 0) from "ls /var/zenoss/percona/bin/pt-online-schema-change"
2015-08-26T19:33:47.082 [ZEP_DATABASE_MAINTENANCE] INFO  org.zenoss.zep.dao.impl.DBMaintenanceServiceImpl - Validating state of event_summary
2015-08-26T19:33:47.084 [ZEP_DATABASE_MAINTENANCE] INFO  org.zenoss.zep.dao.impl.DaoUtils - Running command: /var/zenoss/percona/bin/pt-online-schema-change --statistics --alter "ENGINE=Innodb" D=zenoss_zep,t=event_summary  --alter-foreign-keys-method=drop_swap --host=127.0.0.1 --port=3306 --user=zenoss --password=zenoss --execute
2015-08-26T19:33:47.304 [ZEP_DATABASE_MAINTENANCE-OPTIMIZE] INFO  org.zenoss.zep.dao.impl.DaoUtils - No slaves found.  See --recursion-method if host c551978f8cc4 has slaves.
2015-08-26T19:33:47.304 [ZEP_DATABASE_MAINTENANCE-OPTIMIZE] INFO  org.zenoss.zep.dao.impl.DaoUtils - Not checking slave lag because no slaves were found and --check-slave-lag was not specified.
2015-08-26T19:33:47.311 [ZEP_DATABASE_MAINTENANCE-OPTIMIZE] INFO  org.zenoss.zep.dao.impl.DaoUtils - Operation, tries, wait:
2015-08-26T19:33:47.311 [ZEP_DATABASE_MAINTENANCE-OPTIMIZE] INFO  org.zenoss.zep.dao.impl.DaoUtils -   copy_rows, 10, 0.25
2015-08-26T19:33:47.311 [ZEP_DATABASE_MAINTENANCE-OPTIMIZE] INFO  org.zenoss.zep.dao.impl.DaoUtils -   create_triggers, 10, 1
2015-08-26T19:33:47.311 [ZEP_DATABASE_MAINTENANCE-OPTIMIZE] INFO  org.zenoss.zep.dao.impl.DaoUtils -   drop_triggers, 10, 1
2015-08-26T19:33:47.311 [ZEP_DATABASE_MAINTENANCE-OPTIMIZE] INFO  org.zenoss.zep.dao.impl.DaoUtils -   swap_tables, 10, 1
2015-08-26T19:33:47.311 [ZEP_DATABASE_MAINTENANCE-OPTIMIZE] INFO  org.zenoss.zep.dao.impl.DaoUtils -   update_foreign_keys, 10, 1
2015-08-26T19:33:47.375 [ZEP_DATABASE_MAINTENANCE-OPTIMIZE] INFO  org.zenoss.zep.dao.impl.DaoUtils - Child tables:
2015-08-26T19:33:47.376 [ZEP_DATABASE_MAINTENANCE-OPTIMIZE] INFO  org.zenoss.zep.dao.impl.DaoUtils -   `zenoss_zep`.`event_trigger_signal_spool` (approx. 1 rows)
2015-08-26T19:33:47.376 [ZEP_DATABASE_MAINTENANCE-OPTIMIZE] INFO  org.zenoss.zep.dao.impl.DaoUtils - Will use the drop_swap method to update foreign keys.
2015-08-26T19:33:47.376 [ZEP_DATABASE_MAINTENANCE-OPTIMIZE] INFO  org.zenoss.zep.dao.impl.DaoUtils - Altering `zenoss_zep`.`event_summary`...
2015-08-26T19:33:47.378 [ZEP_DATABASE_MAINTENANCE-OPTIMIZE] INFO  org.zenoss.zep.dao.impl.DaoUtils - Creating new table...
2015-08-26T19:33:47.619 [ZEP_DATABASE_MAINTENANCE-OPTIMIZE] INFO  org.zenoss.zep.dao.impl.DaoUtils - Created new table zenoss_zep._event_summary_new OK.
2015-08-26T19:33:47.620 [ZEP_DATABASE_MAINTENANCE-OPTIMIZE] INFO  org.zenoss.zep.dao.impl.DaoUtils - Altering new table...
2015-08-26T19:33:48.444 [ZEP_DATABASE_MAINTENANCE-OPTIMIZE] INFO  org.zenoss.zep.dao.impl.DaoUtils - Altered `zenoss_zep`.`_event_summary_new` OK.
2015-08-26T19:33:48.448 [ZEP_DATABASE_MAINTENANCE-OPTIMIZE] INFO  org.zenoss.zep.dao.impl.DaoUtils - 2015-08-26T19:33:48 Creating triggers...
2015-08-26T19:33:48.625 [ZEP_DATABASE_MAINTENANCE-OPTIMIZE] INFO  org.zenoss.zep.dao.impl.DaoUtils - 2015-08-26T19:33:48 Created triggers OK.
2015-08-26T19:33:48.627 [ZEP_DATABASE_MAINTENANCE-OPTIMIZE] INFO  org.zenoss.zep.dao.impl.DaoUtils - 2015-08-26T19:33:48 Copying approximately 8 rows...
2015-08-26T19:33:48.630 [ZEP_DATABASE_MAINTENANCE-OPTIMIZE] INFO  org.zenoss.zep.dao.impl.DaoUtils - 2015-08-26T19:33:48 Copied rows OK.
2015-08-26T19:33:48.630 [ZEP_DATABASE_MAINTENANCE-OPTIMIZE] INFO  org.zenoss.zep.dao.impl.DaoUtils - 2015-08-26T19:33:48 Drop-swapping tables...
2015-08-26T19:33:48.645 [ZEP_DATABASE_MAINTENANCE-OPTIMIZE] INFO  org.zenoss.zep.dao.impl.DaoUtils - 2015-08-26T19:33:48 Dropped and swapped tables OK.
2015-08-26T19:33:48.645 [ZEP_DATABASE_MAINTENANCE-OPTIMIZE] INFO  org.zenoss.zep.dao.impl.DaoUtils - Not dropping old table because --no-drop-old-table was specified.
2015-08-26T19:33:48.647 [ZEP_DATABASE_MAINTENANCE-OPTIMIZE] INFO  org.zenoss.zep.dao.impl.DaoUtils - 2015-08-26T19:33:48 Dropping triggers...
2015-08-26T19:33:48.648 [ZEP_DATABASE_MAINTENANCE-OPTIMIZE] INFO  org.zenoss.zep.dao.impl.DaoUtils - 2015-08-26T19:33:48 Dropped triggers OK.
2015-08-26T19:33:48.648 [ZEP_DATABASE_MAINTENANCE-OPTIMIZE] INFO  org.zenoss.zep.dao.impl.DaoUtils - # Event  Count
2015-08-26T19:33:48.648 [ZEP_DATABASE_MAINTENANCE-OPTIMIZE] INFO  org.zenoss.zep.dao.impl.DaoUtils - # ====== =====
2015-08-26T19:33:48.648 [ZEP_DATABASE_MAINTENANCE-OPTIMIZE] INFO  org.zenoss.zep.dao.impl.DaoUtils - # INSERT     1
2015-08-26T19:33:48.648 [ZEP_DATABASE_MAINTENANCE-OPTIMIZE] INFO  org.zenoss.zep.dao.impl.DaoUtils - Successfully altered `zenoss_zep`.`event_summary`.
2015-08-26T19:33:48.651 [ZEP_DATABASE_MAINTENANCE] INFO  org.zenoss.zep.dao.impl.DaoUtils - Command ran successfully (return code: 0) from "/var/zenoss/percona/bin/pt-online-schema-change --statistics --alter "ENGINE=Innodb" D=zenoss_zep,t=event_summary  --alter-foreign-keys-method=drop_swap --host=127.0.0.1 --port=3306 --user=zenoss --password=zenoss --execute"
2015-08-26T19:33:48.655 [ZEP_DATABASE_MAINTENANCE] INFO  org.zenoss.zep.dao.impl.DBMaintenanceServiceImpl - Optimizaton of event_summary (via percona)
```