### PR TITLE
ZEN-19795 Event class names in all lowercase confuse zeneventserver a…

### DIFF
--- a/core/src/main/sql/mysql/009.sql
+++ b/core/src/main/sql/mysql/009.sql
@@ -6,4 +6,27 @@
 
 DROP VIEW v_event_summary_index_queue;
 
+--
+-- Make all of the tables that are cached in DaoCacheImpl case sensitive:
+--
+
+-- Make event_class table case sensitive
+ALTER TABLE event_class CONVERT TO CHARACTER SET utf8 COLLATE utf8_bin;
+
+-- Make event_class_key table case sensitive
+ALTER TABLE event_class_key CONVERT TO CHARACTER SET utf8 COLLATE utf8_bin;
+
+-- Make monitor table case sensitive
+ALTER TABLE monitor CONVERT TO CHARACTER SET utf8 COLLATE utf8_bin;
+
+-- Make agent table case sensitive
+ALTER TABLE agent CONVERT TO CHARACTER SET utf8 COLLATE utf8_bin;
+
+-- Make event_group table case sensitive
+ALTER TABLE event_group CONVERT TO CHARACTER SET utf8 COLLATE utf8_bin;
+
+-- Make event_key table case sensitive
+ALTER TABLE event_key CONVERT TO CHARACTER SET utf8 COLLATE utf8_bin;
+
+
 INSERT INTO schema_version (version, installed_time) VALUES(9, NOW());

--- a/core/src/test/java/org/zenoss/zep/dao/impl/DaoCacheImplIT.java
+++ b/core/src/test/java/org/zenoss/zep/dao/impl/DaoCacheImplIT.java
@@ -40,6 +40,13 @@ public class DaoCacheImplIT extends
         assertEquals(simpleJdbcTemplate.queryForInt(sql, agent), res);
 
         assertEquals(agent, daoCache.getAgentFromId(res));
+
+        //test case sensitivity
+        String agent2 = agent.toUpperCase();
+        int res2 = daoCache.getAgentId(agent2);
+        assertFalse(res == res2);//this should be a new ID
+        assertEquals(agent2, daoCache.getAgentFromId(res2)); //Should still work both ways
+        assertEquals(agent, daoCache.getAgentFromId(res)); //We didn't overwrite the previous entry
     }
 
     @Test
@@ -53,6 +60,13 @@ public class DaoCacheImplIT extends
         assertEquals(simpleJdbcTemplate.queryForInt(sql, eventClass), res);
 
         assertEquals(eventClass, daoCache.getEventClassFromId(res));
+
+        //test case sensitivity
+        String eventClass2 = eventClass.toUpperCase();
+        int res2 = daoCache.getEventClassId(eventClass2);
+        assertFalse(res == res2);//this should be a new ID
+        assertEquals(eventClass2, daoCache.getEventClassFromId(res2)); //Should still work both ways
+        assertEquals(eventClass, daoCache.getEventClassFromId(res)); //We didn't overwrite the previous entry
     }
 
     @Test
@@ -66,6 +80,13 @@ public class DaoCacheImplIT extends
         assertEquals(simpleJdbcTemplate.queryForInt(sql, eventClassKey), res);
 
         assertEquals(eventClassKey, daoCache.getEventClassKeyFromId(res));
+
+        //test case sensitivity
+        String eventClassKey2 = eventClassKey.toUpperCase();
+        int res2 = daoCache.getEventClassKeyId(eventClassKey2);
+        assertFalse(res == res2);//this should be a new ID
+        assertEquals(eventClassKey2, daoCache.getEventClassKeyFromId(res2)); //Should still work both ways
+        assertEquals(eventClassKey, daoCache.getEventClassKeyFromId(res)); //We didn't overwrite the previous entry
     }
 
     @Test
@@ -79,6 +100,13 @@ public class DaoCacheImplIT extends
         assertEquals(simpleJdbcTemplate.queryForInt(sql, eventGroup), res);
 
         assertEquals(eventGroup, daoCache.getEventGroupFromId(res));
+
+        //test case sensitivity
+        String eventGroup2 = eventGroup.toUpperCase();
+        int res2 = daoCache.getEventGroupId(eventGroup2);
+        assertFalse(res == res2);//this should be a new ID
+        assertEquals(eventGroup2, daoCache.getEventGroupFromId(res2)); //Should still work both ways
+        assertEquals(eventGroup, daoCache.getEventGroupFromId(res)); //We didn't overwrite the previous entry
     }
 
     @Test
@@ -92,6 +120,13 @@ public class DaoCacheImplIT extends
         assertEquals(simpleJdbcTemplate.queryForInt(sql, monitor), res);
 
         assertEquals(monitor, daoCache.getMonitorFromId(res));
+
+        //test case sensitivity
+        String monitor2 = monitor.toUpperCase();
+        int res2 = daoCache.getMonitorId(monitor2);
+        assertFalse(res == res2);//this should be a new ID
+        assertEquals(monitor2, daoCache.getMonitorFromId(res2)); //Should still work both ways
+        assertEquals(monitor, daoCache.getMonitorFromId(res)); //We didn't overwrite the previous entry
     }
 
     @Test
@@ -105,6 +140,13 @@ public class DaoCacheImplIT extends
         assertEquals(simpleJdbcTemplate.queryForInt(sql, eventKey), res);
 
         assertEquals(eventKey, daoCache.getEventKeyFromId(res));
+
+        //test case sensitivity
+        String eventKey2 = eventKey.toUpperCase();
+        int res2 = daoCache.getEventKeyId(eventKey2);
+        assertFalse(res == res2);//this should be a new ID
+        assertEquals(eventKey2, daoCache.getEventKeyFromId(res2)); //Should still work both ways
+        assertEquals(eventKey, daoCache.getEventKeyFromId(res)); //We didn't overwrite the previous entry
     }
 
 }


### PR DESCRIPTION
…nd break triggers

https://jira.zenoss.com/browse/ZEN-19795

Problem was caused by the "name" column in the event_class table being case-insensitive in mysql.  I modified the tables used by DaoCacheImpl to be case sensitive, and added integration test code to test for case-sensitivity.
