### PR TITLE
ZEN-20035: Within the Event Console, Device Class filter is not worki…

### DIFF
--- a/core/src/main/java/org/zenoss/zep/index/impl/lucene/LuceneQueryBuilder.java
+++ b/core/src/main/java/org/zenoss/zep/index/impl/lucene/LuceneQueryBuilder.java
@@ -385,7 +385,7 @@ public class LuceneQueryBuilder extends BaseQueryBuilder<LuceneQueryBuilder> {
                 }
                 // Prefix
                 else if (value.endsWith("*")) {
-                    value = value.substring(0, value.length() - 1);
+                    value = StringUtils.trimTrailingCharacter(value, '*');
                     filter = filterCache.get(PREFIX, new Term(nonAnalyzed(fieldName), value));
                 }
                 // Exact match


### PR DESCRIPTION
Please see last comment from the customer for https://zenoss.zendesk.com/agent/tickets/107578

Without these changes in case of "/CiscoUCS* || /Server*" filter we have next ouputs.

logging for: https://github.com/zenoss/zenoss-zep/blob/develop/core/src/main/java/org/zenoss/zep/index/impl/lucene/LuceneQueryBuilder.java#L386
is here: https://gist.github.com/olst/11d053ec2642c4d0a969
```
2015-11-04T12:29:59.067 [qtp405519671-14 - http://127.0.0.1:8084/zeneventserver/api/1.0/events/] INFO  org.zenoss.zep.index.impl.BaseQueryBuilder - input value = /server*
2015-11-04T12:29:59.067 [qtp405519671-18 - http://127.0.0.1:8084/zeneventserver/api/1.0/events/] INFO  org.zenoss.zep.index.impl.BaseQueryBuilder - output value = /server
2015-11-04T12:29:59.074 [qtp405519671-18 - http://127.0.0.1:8084/zeneventserver/api/1.0/events/] INFO  org.zenoss.zep.index.impl.BaseQueryBuilder - input value = /ciscoucs**
2015-11-04T12:29:59.074 [qtp405519671-18 - http://127.0.0.1:8084/zeneventserver/api/1.0/events/] INFO  org.zenoss.zep.index.impl.BaseQueryBuilder - output value = /ciscoucs*
```
Because of the value with trailing asterisk ('/ciscoucs\*') filter "/CiscoUCS* || /Server*" is not working.