### PR TITLE
ZEN-21534: Make ZEP DB updates persistent

### DIFF
--- a/dist/src/assembly/bin/zeneventserver-create-db
+++ b/dist/src/assembly/bin/zeneventserver-create-db
@@ -307,10 +307,14 @@ if __name__ == '__main__':
             migrator.initializeDatabase()
         current_version = migrator.getSchemaVersion()
         log.debug('Current schema version: %d', current_version)
+        schema_count = 0
         for schema_version, schema_file in schema_files:
             if schema_version > current_version:
                 print 'Applying schema version: %d' % schema_version
+                schema_count += 1
                 migrator.applySchemaFile(schema_file)
+        if schema_count == 0:
+            print 'No schema updates to apply'
     except subprocess.CalledProcessError as e:
         sys.exit(e.returncode)
     except RuntimeError as e:


### PR DESCRIPTION
During 5.0.x -> 5.1.0 upgrades, the ZEP DB updates were not persisting.
Per JP, this was because they were being run within the Zope container
which does not import the ZEP mariadb.

Would be nice to add an "update" command to the zeneventserver service
to parallel the one in zope.  But that leads to the circular "have to
update the service to add the command to call to update the service..."
problem.

So instead, we'll apply any outstanding updates when starting
zeneventserver.