### PR TITLE
Make metric names stable

### DIFF
--- a/core/src/main/java/org/zenoss/zep/dao/impl/EventArchiveDaoImpl.java
+++ b/core/src/main/java/org/zenoss/zep/dao/impl/EventArchiveDaoImpl.java
@@ -82,7 +82,7 @@ public class EventArchiveDaoImpl implements EventArchiveDao {
 
     @Override
     @TransactionalRollbackAllExceptions
-    @Timed
+    @Timed(absolute=true, name="zeneventserver.EventArchive.create")
     public String create(Event event, EventPreCreateContext context) throws ZepException {
         if (!ZepConstants.CLOSED_STATUSES.contains(event.getStatus())) {
             throw new ZepException("Invalid status for event in event archive: " + event.getStatus());
@@ -109,7 +109,7 @@ public class EventArchiveDaoImpl implements EventArchiveDao {
 
     @Override
     @TransactionalReadOnly
-    @Timed
+    @Timed(absolute=true, name="zeneventserver.EventArchive.findByUuid")
     public EventSummary findByUuid(String uuid) throws ZepException {
         final Map<String,Object> fields = Collections.singletonMap(COLUMN_UUID, uuidConverter.toDatabaseType(uuid));
         List<EventSummary> summaries = this.template.query("SELECT * FROM event_archive WHERE uuid=:uuid",
@@ -120,7 +120,7 @@ public class EventArchiveDaoImpl implements EventArchiveDao {
     @Override
     @TransactionalReadOnly
     @Deprecated
-    @Timed
+    @Timed(absolute=true, name="zeneventserver.EventArchive.findByUuids")
     /** @deprecated use {@link #findByKey(Collection) instead}. */
     public List<EventSummary> findByUuids(List<String> uuids)
             throws ZepException {
@@ -133,7 +133,7 @@ public class EventArchiveDaoImpl implements EventArchiveDao {
 
     @Override
     @TransactionalReadOnly
-    @Timed
+    @Timed(absolute=true, name="zeneventserver.EventArchive.findByKey")
     public List<EventSummary> findByKey(Collection<EventSummary> toLookup) throws ZepException {
         ArrayList<Object> fields = new ArrayList<Object>(toLookup.size() * 2);
         StringBuilder sql = new StringBuilder();
@@ -153,7 +153,7 @@ public class EventArchiveDaoImpl implements EventArchiveDao {
 
     @Override
     @TransactionalReadOnly
-    @Timed
+    @Timed(absolute=true, name="zeneventserver.EventArchive.listBatch")
     public EventBatch listBatch(EventBatchParams batchParams, long maxUpdateTime, int limit) throws ZepException {
         return this.eventDaoHelper.listBatch(this.template, TABLE_EVENT_ARCHIVE, this.partitioner, batchParams, maxUpdateTime, limit,
                 new EventArchiveRowMapper(eventDaoHelper, databaseCompatibility));
@@ -161,7 +161,7 @@ public class EventArchiveDaoImpl implements EventArchiveDao {
 
     @Override
     @TransactionalRollbackAllExceptions
-    @Timed
+    @Timed(absolute=true, name="zeneventserver.EventArchive.initializePartitions")
     public void initializePartitions() throws ZepException {
         this.partitioner.createPartitions(
                 this.partitionTableConfig.getInitialPastPartitions(),
@@ -169,7 +169,7 @@ public class EventArchiveDaoImpl implements EventArchiveDao {
     }
 
     @Override
-    @Timed
+    @Timed(absolute=true, name="zeneventserver.EventArchive.getPartitionIntervalInMs")
     public long getPartitionIntervalInMs() {
         return this.partitionTableConfig.getPartitionUnit().toMillis(
                 this.partitionTableConfig.getPartitionDuration());
@@ -177,14 +177,14 @@ public class EventArchiveDaoImpl implements EventArchiveDao {
 
     @Override
     @TransactionalRollbackAllExceptions
-    @Timed
+    @Timed(absolute=true, name="zeneventserver.EventArchive.addNote")
     public int addNote(String uuid, EventNote note) throws ZepException {
         return this.eventDaoHelper.addNote(TABLE_EVENT_ARCHIVE, uuid, note, template);
     }
 
     @Override
     @TransactionalRollbackAllExceptions
-    @Timed
+    @Timed(absolute=true, name="zeneventserver.EventArchive.updateDetails")
     public int updateDetails(String uuid, EventDetailSet details)
             throws ZepException {
         return this.eventDaoHelper.updateDetails(TABLE_EVENT_ARCHIVE, uuid, details.getDetailsList(), template);
@@ -192,7 +192,7 @@ public class EventArchiveDaoImpl implements EventArchiveDao {
 
     @Override
     @TransactionalRollbackAllExceptions
-    @Timed
+    @Timed(absolute=true, name="zeneventserver.EventArchive.purge")
     public void purge(int duration, TimeUnit unit) throws ZepException {
         this.partitioner.pruneAndCreatePartitions(duration,
                 unit,
@@ -202,7 +202,7 @@ public class EventArchiveDaoImpl implements EventArchiveDao {
 
     @Override
     @TransactionalRollbackAllExceptions
-    @Timed
+    @Timed(absolute=true, name="zeneventserver.EventArchive.importEvent")
     public void importEvent(EventSummary eventSummary) throws ZepException {
         if (!ZepConstants.CLOSED_STATUSES.contains(eventSummary.getStatus())) {
             throw new ZepException("Invalid status for event in event archive: " + eventSummary.getStatus());

--- a/core/src/main/java/org/zenoss/zep/dao/impl/EventSummaryDaoImpl.java
+++ b/core/src/main/java/org/zenoss/zep/dao/impl/EventSummaryDaoImpl.java
@@ -182,7 +182,7 @@ public class EventSummaryDaoImpl implements EventSummaryDao {
     }
 
     @Override
-    @Timed
+    @Timed(absolute=true, name="zeneventserver.EventSummary.create")
     @TransactionalRollbackAllExceptions
     public String create(Event event, final EventPreCreateContext context) throws ZepException {
 
@@ -636,7 +636,7 @@ public class EventSummaryDaoImpl implements EventSummaryDao {
 
     @Override
     @TransactionalRollbackAllExceptions
-    @Timed
+    @Timed(absolute=true, name="zeneventserver.EventSummary.reidentify")
     public int reidentify(ModelElementType type, String id, String uuid, String title, String parentUuid)
             throws ZepException {
         TypeConverter<Long> timestampConverter = databaseCompatibility.getTimestampConverter();
@@ -696,7 +696,7 @@ public class EventSummaryDaoImpl implements EventSummaryDao {
 
     @Override
     @TransactionalRollbackAllExceptions
-    @Timed
+    @Timed(absolute=true, name="zeneventserver.EventSummary.deidentify")
     public int deidentify(String uuid) throws ZepException {
         TypeConverter<Long> timestampConverter = databaseCompatibility.getTimestampConverter();
         long updateTime = System.currentTimeMillis();
@@ -739,7 +739,7 @@ public class EventSummaryDaoImpl implements EventSummaryDao {
 
     @Override
     @TransactionalReadOnly
-    @Timed
+    @Timed(absolute=true, name="zeneventserver.EventSummary.findByUuid")
     public EventSummary findByUuid(String uuid) throws ZepException {
         final Map<String, Object> fields = Collections.singletonMap(COLUMN_UUID, uuidConverter.toDatabaseType(uuid));
         List<EventSummary> summaries = this.template.query("SELECT * FROM event_summary WHERE uuid=:uuid",
@@ -749,7 +749,7 @@ public class EventSummaryDaoImpl implements EventSummaryDao {
 
     @Override
     @Deprecated
-    @Timed
+    @Timed(absolute=true, name="zeneventserver.EventSummary.findByUuids")
     /** @deprecated use {@link #findByKey(Collection) instead}. */
     public List<EventSummary> findByUuids(final List<String> uuids) throws ZepException {
         return findByUuids((Collection) uuids);
@@ -769,7 +769,7 @@ public class EventSummaryDaoImpl implements EventSummaryDao {
 
     @Override
     @TransactionalReadOnly
-    @Timed
+    @Timed(absolute=true, name="zeneventserver.EventSummary.findByKey")
     /**
      * This implementation only makes use of the UUID field to lookup the events.
      */
@@ -783,7 +783,7 @@ public class EventSummaryDaoImpl implements EventSummaryDao {
 
     @Override
     @TransactionalReadOnly
-    @Timed
+    @Timed(absolute=true, name="zeneventserver.EventSummary.listBatch")
     public EventBatch listBatch(EventBatchParams batchParams, long maxUpdateTime, int limit) throws ZepException {
         return this.eventDaoHelper.listBatch(this.template, TABLE_EVENT_SUMMARY, null, batchParams, maxUpdateTime, limit,
                 new EventSummaryRowMapper(eventDaoHelper, databaseCompatibility));
@@ -802,7 +802,7 @@ public class EventSummaryDaoImpl implements EventSummaryDao {
     }
 
     @Override
-    @Timed
+    @Timed(absolute=true, name="zeneventserver.EventSummary.getAgeEligibleEventCount")
     public long getAgeEligibleEventCount(long duration, TimeUnit unit, EventSeverity maxSeverity,
                                          boolean inclusiveSeverity) {
         List<Integer> severityIds = getSeverityIds(maxSeverity, inclusiveSeverity);
@@ -819,7 +819,7 @@ public class EventSummaryDaoImpl implements EventSummaryDao {
 
     @Override
     @TransactionalRollbackAllExceptions
-    @Timed
+    @Timed(absolute=true, name="zeneventserver.EventSummary.ageEvents")
     public int ageEvents(long agingInterval, TimeUnit unit,
                          EventSeverity maxSeverity, int limit, boolean inclusiveSeverity) throws ZepException {
         TypeConverter<Long> timestampConverter = databaseCompatibility.getTimestampConverter();
@@ -892,7 +892,7 @@ public class EventSummaryDaoImpl implements EventSummaryDao {
 
     @Override
     @TransactionalRollbackAllExceptions
-    @Timed
+    @Timed(absolute=true, name="zeneventserver.EventSummary.addNote")
     public int addNote(String uuid, EventNote note) throws ZepException {
         final long updateTime = System.currentTimeMillis();
         this.indexSignal(uuid);
@@ -902,7 +902,7 @@ public class EventSummaryDaoImpl implements EventSummaryDao {
 
     @Override
     @TransactionalRollbackAllExceptions
-    @Timed
+    @Timed(absolute=true, name="zeneventserver.EventSummary.updateDetails")
     public int updateDetails(String uuid, EventDetailSet details)
             throws ZepException {
         final long updateTime = System.currentTimeMillis();
@@ -1113,7 +1113,7 @@ public class EventSummaryDaoImpl implements EventSummaryDao {
 
     @Override
     @TransactionalRollbackAllExceptions
-    @Timed
+    @Timed(absolute=true, name="zeneventserver.EventSummary.acknowledge")
     public int acknowledge(List<String> uuids, String userUuid, String userName)
             throws ZepException {
         /* NEW | ACKNOWLEDGED | SUPPRESSED -> ACKNOWLEDGED */
@@ -1134,7 +1134,7 @@ public class EventSummaryDaoImpl implements EventSummaryDao {
     }
 
     @Override
-    @Timed
+    @Timed(absolute=true, name="zeneventserver.EventSummary.getArchiveEligibleEventCount")
     public long getArchiveEligibleEventCount(long duration, TimeUnit unit) {
         String sql = "SELECT COUNT(*) FROM event_summary WHERE closed_status = TRUE AND last_seen < :_last_seen";
         Map<String, Object> fields = createSharedFields(duration, unit);
@@ -1143,7 +1143,7 @@ public class EventSummaryDaoImpl implements EventSummaryDao {
 
     @Override
     @TransactionalRollbackAllExceptions
-    @Timed
+    @Timed(absolute=true, name="zeneventserver.EventSummary.archive")
     public int archive(long duration, TimeUnit unit, int limit) throws ZepException {
         Map<String, Object> fields = createSharedFields(duration, unit);
         fields.put("_limit", limit);
@@ -1162,7 +1162,7 @@ public class EventSummaryDaoImpl implements EventSummaryDao {
 
     @Override
     @TransactionalRollbackAllExceptions
-    @Timed
+    @Timed(absolute=true, name="zeneventserver.EventSummary.close")
     public int close(List<String> uuids, String userUuid, String userName) throws ZepException {
         /* NEW | ACKNOWLEDGED | SUPPRESSED -> CLOSED */
         List<EventStatus> currentStatuses = Arrays.asList(EventStatus.STATUS_NEW, EventStatus.STATUS_ACKNOWLEDGED,
@@ -1175,7 +1175,7 @@ public class EventSummaryDaoImpl implements EventSummaryDao {
 
     @Override
     @TransactionalRollbackAllExceptions
-    @Timed
+    @Timed(absolute=true, name="zeneventserver.EventSummary.reopen")
     public int reopen(List<String> uuids, String userUuid, String userName) throws ZepException {
         /* CLOSED | CLEARED | AGED | ACKNOWLEDGED | SUPPRESSED -> NEW */
         List<EventStatus> currentStatuses = Arrays.asList(EventStatus.STATUS_CLOSED, EventStatus.STATUS_CLEARED,
@@ -1188,7 +1188,7 @@ public class EventSummaryDaoImpl implements EventSummaryDao {
 
     @Override
     @TransactionalRollbackAllExceptions
-    @Timed
+    @Timed(absolute=true, name="zeneventserver.EventSummary.suppress")
     public int suppress(List<String> uuids) throws ZepException {
         /* NEW -> SUPPRESSED */
         List<EventStatus> currentStatuses = Arrays.asList(EventStatus.STATUS_NEW);
@@ -1197,7 +1197,7 @@ public class EventSummaryDaoImpl implements EventSummaryDao {
 
     @Override
     @TransactionalRollbackAllExceptions
-    @Timed
+    @Timed(absolute=true, name="zeneventserver.EventSummary.archiveList")
     public int archive(List<String> uuids) throws ZepException {
         if (uuids.isEmpty()) {
             return 0;
@@ -1250,7 +1250,7 @@ public class EventSummaryDaoImpl implements EventSummaryDao {
 
     @Override
     @TransactionalRollbackAllExceptions
-    @Timed
+    @Timed(absolute=true, name="zeneventserver.EventSummary.importEvent")
     public void importEvent(EventSummary eventSummary) throws ZepException {
         final long updateTime = System.currentTimeMillis();
         final EventSummary.Builder summaryBuilder = EventSummary.newBuilder(eventSummary);

--- a/core/src/main/java/org/zenoss/zep/impl/EventProcessorImpl.java
+++ b/core/src/main/java/org/zenoss/zep/impl/EventProcessorImpl.java
@@ -81,7 +81,7 @@ public class EventProcessorImpl implements EventProcessor {
     }
 
     @Override
-    @Timed
+    @Timed(absolute=true, name="zeneventserver.EventProcessor.processEvent")
     public void processEvent(ZepRawEvent zepRawEvent) throws ZepException {
         logger.debug("processEvent: event={}", zepRawEvent);
         counters.addToProcessedEventCount(1);

--- a/core/src/main/java/org/zenoss/zep/impl/EventPublisherImpl.java
+++ b/core/src/main/java/org/zenoss/zep/impl/EventPublisherImpl.java
@@ -38,7 +38,7 @@ public class EventPublisherImpl implements EventPublisher {
     }
 
     @Override
-    @Timed
+    @Timed(absolute=true, name="zeneventserver.EventPublisher.publishEvent")
     public void publishEvent(Event rawEvent) throws ZepException {
         try {
             this.connectionManager.publish(exchangeConfiguration, createRoutingKey(rawEvent), rawEvent);

--- a/core/src/main/java/org/zenoss/zep/index/impl/EventIndexerImpl.java
+++ b/core/src/main/java/org/zenoss/zep/index/impl/EventIndexerImpl.java
@@ -186,13 +186,13 @@ public class EventIndexerImpl implements EventIndexer, ApplicationListener<ZepCo
     }
 
     @Override
-    @Timed
+    @Timed(absolute=true, name="zeneventserver.EventIndexer.index")
     public synchronized int index() throws ZepException {
         return doIndex(-1L);
     }
 
     @Override
-    @Timed
+    @Timed(absolute=true, name="zeneventserver.EventIndexer.indexFully")
     public int indexFully() throws ZepException {
         int totalIndexed = 0;
         final long now = System.currentTimeMillis();

--- a/core/src/main/java/org/zenoss/zep/rest/EventsResource.java
+++ b/core/src/main/java/org/zenoss/zep/rest/EventsResource.java
@@ -165,7 +165,7 @@ public class EventsResource {
     @Path("search")
     @Consumes({ MediaType.APPLICATION_JSON, ProtobufConstants.CONTENT_TYPE_PROTOBUF })
     @GZIP
-    @Timed
+    @Timed(absolute=true, name="zeneventserver.EventsResource.createSavedSearch")
     public Response createSavedSearch(EventQuery query, @Context UriInfo ui) throws URISyntaxException, ZepException {
         return createSavedSearchInternal(this.eventSummaryIndexDao, query, ui);
     }
@@ -174,7 +174,7 @@ public class EventsResource {
     @Path("archive/search")
     @Consumes({ MediaType.APPLICATION_JSON, ProtobufConstants.CONTENT_TYPE_PROTOBUF })
     @GZIP
-    @Timed
+    @Timed(absolute=true, name="zeneventserver.EventsResource.createArchiveSavedSearch")
     public Response createArchiveSavedSearch(EventQuery query, @Context UriInfo ui) throws URISyntaxException, ZepException {
         return createSavedSearchInternal(this.eventArchiveIndexDao, query, ui);
     }
@@ -191,7 +191,7 @@ public class EventsResource {
     @Path("search/{searchUuid}")
     @Produces({ MediaType.APPLICATION_JSON, ProtobufConstants.CONTENT_TYPE_PROTOBUF })
     @GZIP
-    @Timed
+    @Timed(absolute=true, name="zeneventserver.EventsResource.listSavedSearch")
     public Response listSavedSearch(@PathParam("searchUuid") String searchUuid,
                                     @QueryParam("offset") String offsetStr,
                                     @QueryParam("limit") String limitStr) throws ZepException {
@@ -202,7 +202,7 @@ public class EventsResource {
     @Path("archive/search/{searchUuid}")
     @Produces({ MediaType.APPLICATION_JSON, ProtobufConstants.CONTENT_TYPE_PROTOBUF })
     @GZIP
-    @Timed
+    @Timed(absolute=true, name="zeneventserver.EventsResource.listArchiveSavedSearch")
     public Response listArchiveSavedSearch(@PathParam("searchUuid") String searchUuid,
                                     @QueryParam("offset") String offsetStr,
                                     @QueryParam("limit") String limitStr) throws ZepException {
@@ -242,7 +242,7 @@ public class EventsResource {
     @DELETE
     @Path("search/{searchUuid}")
     @GZIP
-    @Timed
+    @Timed(absolute=true, name="zeneventserver.EventsResource.deleteSavedSearch")
     public Response deleteSavedSearch(@PathParam("searchUuid") String searchUuid) throws ZepException {
         return deleteSavedSearchInternal(this.eventSummaryIndexDao, searchUuid);
     }
@@ -250,7 +250,7 @@ public class EventsResource {
     @DELETE
     @Path("archive/search/{searchUuid}")
     @GZIP
-    @Timed
+    @Timed(absolute=true, name="zeneventserver.EventsResource.deleteArchiveSavedSearch")
     public Response deleteArchiveSavedSearch(@PathParam("searchUuid") String searchUuid) throws ZepException {
         return deleteSavedSearchInternal(this.eventArchiveIndexDao, searchUuid);
     }
@@ -267,7 +267,7 @@ public class EventsResource {
     @Path("search/{searchUuid}")
     @Produces({ MediaType.APPLICATION_JSON, ProtobufConstants.CONTENT_TYPE_PROTOBUF })
     @GZIP
-    @Timed
+    @Timed(absolute=true, name="zeneventserver.EventsResource.updateEvents")
     public EventSummaryUpdateResponse updateEvents(@PathParam("searchUuid") String searchUuid,
                                                    EventSummaryUpdateRequest request) throws ZepException {
         if (request.hasEventQueryUuid() && !searchUuid.equals(request.getEventQueryUuid())) {
@@ -307,7 +307,7 @@ public class EventsResource {
     @Path("{eventUuid}")
     @Produces({ MediaType.APPLICATION_JSON, ProtobufConstants.CONTENT_TYPE_PROTOBUF })
     @GZIP
-    @Timed
+    @Timed(absolute=true, name="zeneventserver.EventsResource.getEventSummaryByUuid")
     public Response getEventSummaryByUuid(@PathParam("eventUuid") String eventUuid) throws ZepException {
         EventSummary summary = eventStoreDao.findByUuid(eventUuid);
         if (summary == null) {
@@ -321,7 +321,7 @@ public class EventsResource {
     @Path("{eventUuid}")
     @Consumes({ MediaType.APPLICATION_JSON, ProtobufConstants.CONTENT_TYPE_PROTOBUF })
     @GZIP
-    @Timed
+    @Timed(absolute=true, name="zeneventserver.EventsResource.updateEventSummaryByUuid")
     public Response updateEventSummaryByUuid(@PathParam("eventUuid") String uuid, EventSummaryUpdate update)
             throws ZepException {
 
@@ -342,7 +342,7 @@ public class EventsResource {
     @Path("{eventUuid}/notes")
     @Consumes({ MediaType.APPLICATION_JSON, ProtobufConstants.CONTENT_TYPE_PROTOBUF })
     @GZIP
-    @Timed
+    @Timed(absolute=true, name="zeneventserver.EventsResource.addNote")
     public Response addNote(@PathParam("eventUuid") String eventUuid, EventNote note) throws ZepException {
 
         EventSummary summary = eventStoreDao.findByUuid(eventUuid);
@@ -368,7 +368,7 @@ public class EventsResource {
     @Path("notes_async")
     @Consumes({ MediaType.APPLICATION_JSON, ProtobufConstants.CONTENT_TYPE_PROTOBUF })
     @GZIP
-    @Timed
+    @Timed(absolute=true, name="zeneventserver.EventsResource.addNoteBulkAsync")
     public Response addNoteBulkAsync(@QueryParam("uuid") Set<String> uuids, EventNote note) throws ZepException {
         if (uuids == null)
             return Response.noContent().build();
@@ -398,7 +398,7 @@ public class EventsResource {
     @Path("/")
     @Produces({ MediaType.APPLICATION_JSON, ProtobufConstants.CONTENT_TYPE_PROTOBUF })
     @GZIP
-    @Timed
+    @Timed(absolute=true, name="zeneventserver.EventsResource.listEventIndex")
     public EventSummaryResult listEventIndex(EventSummaryRequest request)
             throws ZepException {
         return this.eventSummaryIndexDao.list(request);
@@ -435,7 +435,7 @@ public class EventsResource {
     @Path("archive")
     @Produces({ MediaType.APPLICATION_JSON, ProtobufConstants.CONTENT_TYPE_PROTOBUF })
     @GZIP
-    @Timed
+    @Timed(absolute=true, name="zeneventserver.EventsResource.listEventIndexArchive")
     public EventSummaryResult listEventIndexArchive(EventSummaryRequest request)
             throws ZepException {
         return this.getEventArchiveResults(request);
@@ -445,7 +445,7 @@ public class EventsResource {
     @Path("/")
     @Produces({ MediaType.APPLICATION_JSON, ProtobufConstants.CONTENT_TYPE_PROTOBUF })
     @GZIP
-    @Timed
+    @Timed(absolute=true, name="zeneventserver.EventsResource.listEventIndexGet")
     public EventSummaryResult listEventIndexGet(@Context UriInfo ui)
             throws ParseException, ZepException {
         return this.eventSummaryIndexDao.list(eventSummaryRequestFromUriInfo(ui));
@@ -455,7 +455,7 @@ public class EventsResource {
     @Path("archive")
     @Produces({ MediaType.APPLICATION_JSON, ProtobufConstants.CONTENT_TYPE_PROTOBUF })
     @GZIP
-    @Timed
+    @Timed(absolute=true, name="zeneventserver.EventsResource.listEventIndexArchiveGet")
     public EventSummaryResult listEventIndexArchiveGet(@Context UriInfo ui)
             throws ParseException, ZepException {
         return this.getEventArchiveResults(eventSummaryRequestFromUriInfo(ui));
@@ -465,7 +465,7 @@ public class EventsResource {
     @Path("tag_severities")
     @Produces({ MediaType.APPLICATION_JSON, ProtobufConstants.CONTENT_TYPE_PROTOBUF })
     @GZIP
-    @Timed
+    @Timed(absolute=true, name="zeneventserver.EventsResource.getEventTagSeverities")
     public EventTagSeveritiesSet getEventTagSeverities(EventFilter filter) throws ZepException {
         return this.eventSummaryIndexDao.getEventTagSeverities(filter);
     }
@@ -474,7 +474,7 @@ public class EventsResource {
     @Path("{eventUuid}/details")
     @Consumes({ MediaType.APPLICATION_JSON, ProtobufConstants.CONTENT_TYPE_PROTOBUF })
     @GZIP
-    @Timed
+    @Timed(absolute=true, name="zeneventserver.EventsResource.updateEventDetails")
     public Response updateEventDetails(@PathParam("eventUuid") String eventUuid, EventDetailSet details) throws ZepException {
         logger.debug("updateEventDetails Enter");
         int numRows = eventStoreDao.updateDetails(eventUuid, details);


### PR DESCRIPTION
https://jira.zenoss.com/browse/ZEN-27970
Decorate the DropWizard annotation to use stable metric names, rather than the java class path.