### PR TITLE
Change non-annotated stats to stable names

### DIFF
--- a/core/src/main/java/org/zenoss/zep/dao/impl/EventIndexQueueDaoImpl.java
+++ b/core/src/main/java/org/zenoss/zep/dao/impl/EventIndexQueueDaoImpl.java
@@ -58,7 +58,7 @@ public class EventIndexQueueDaoImpl implements EventIndexQueueDao, ApplicationEv
     public void setMetrics(MetricRegistry metrics) {
 	this.metrics = metrics;
         String metricName = "";
-        String baseName = this.getClass().getCanonicalName();
+        String baseName = "EventIndexQueueDaoImpl";
         this.indexedCounter = metrics.counter(MetricRegistry.name(baseName, indexDaoDelegate.getQueueName(), "indexed"));
         metricName = MetricRegistry.name(baseName, indexDaoDelegate.getQueueName(), "size");
         this.metrics.register(metricName, new Gauge<Long>() {

--- a/core/src/main/java/org/zenoss/zep/dao/impl/EventSummaryDaoImpl.java
+++ b/core/src/main/java/org/zenoss/zep/dao/impl/EventSummaryDaoImpl.java
@@ -194,7 +194,7 @@ public class EventSummaryDaoImpl implements EventSummaryDao {
         if (event.getSeverity() == EventSeverity.SEVERITY_CLEAR) {
             final Event finalEvent = event;
             try {
-                clearedEventUuids = metricRegistry.timer(getClass().getName() + ".clearEvents").time(new Callable<List<String>>() {
+                clearedEventUuids = metricRegistry.timer("EventSummaryDaoImpl.clearEvents").time(new Callable<List<String>>() {
                     @Override
                     public List<String> call() throws Exception {
                         return clearEvents(finalEvent, context);
@@ -243,7 +243,7 @@ public class EventSummaryDaoImpl implements EventSummaryDao {
             final String hashAsString = new String(fingerprintHash).intern();
             final Event finalEvent = event;
             try {
-                metricRegistry.timer(getClass().getName() + ".queueDedup").time(new Callable() {
+                metricRegistry.timer("EventSummaryDaoImpl.queueDedup").time(new Callable() {
                     @Override
                     public Object call() throws Exception {
                         boolean queued = false;
@@ -267,7 +267,7 @@ public class EventSummaryDaoImpl implements EventSummaryDao {
             }
 
             try {
-                uuid = metricRegistry.timer(getClass().getName() + ".dedupSync").time(new Callable<String>() {
+                uuid = metricRegistry.timer("EventSummaryDaoImpl.dedupSync").time(new Callable<String>() {
                     @Override
                     public String call() throws Exception {
                         synchronized (hashAsString) {
@@ -296,7 +296,7 @@ public class EventSummaryDaoImpl implements EventSummaryDao {
             return null;
         }
         try {
-            metricRegistry.timer(getClass().getName() + ".dedupClearEvents").time(new Callable<Object>() {
+            metricRegistry.timer("EventSummaryDaoImpl.dedupClearEvents").time(new Callable<Object>() {
                 @Override
                 public Object call() throws Exception {
                     // Mark cleared events as cleared by this event
@@ -345,7 +345,7 @@ public class EventSummaryDaoImpl implements EventSummaryDao {
                                           final EventPreCreateContext context, final boolean createClearHash)
             throws ZepException {
         try {
-            return metricRegistry.timer(getClass().getName() + ".saveEventByFingerprint").time(new Callable<String>() {
+            return metricRegistry.timer("EventSummaryDaoImpl.saveEventByFingerprint").time(new Callable<String>() {
                 @Override
                 public String call() throws Exception {
                     final List<EventSummary.Builder> oldSummaryList = template.getJdbcOperations().query(

--- a/core/src/main/java/org/zenoss/zep/impl/AbstractQueueListener.java
+++ b/core/src/main/java/org/zenoss/zep/impl/AbstractQueueListener.java
@@ -34,17 +34,17 @@ public abstract class AbstractQueueListener extends QueueListener {
     @Autowired
     protected MetricRegistry metricRegistry;
 
-    private final String ackMessageTimerName     = this.getClass().getName() + ".ackMessage";
-    private final String handleMessageTimerName  = this.getClass().getName() + ".handleMessage";
-    private final String receiveMessageTimerName = this.getClass().getName() + ".receiveMessage";
-    private final String rejectMessageTimerName  = this.getClass().getName() + ".rejectMessage";
+    private final String ackMessageTimerName     = this.getClass().getSimpleName() + ".ackMessage";
+    private final String handleMessageTimerName  = this.getClass().getSimpleName() + ".handleMessage";
+    private final String receiveMessageTimerName = this.getClass().getSimpleName() + ".receiveMessage";
+    private final String rejectMessageTimerName  = this.getClass().getSimpleName() + ".rejectMessage";
 
     protected abstract String getQueueIdentifier();
-
 
     public void setExecutorService(ExecutorService executorService) {
         this.executorService = executorService;
     }
+    
     protected void rejectMessage(final Consumer<?> consumer, final Message<?> message, final boolean requeue) {
         try {
             metricRegistry.timer(rejectMessageTimerName).time(new Callable<Object>() {

--- a/core/src/main/java/org/zenoss/zep/impl/EventProcessorImpl.java
+++ b/core/src/main/java/org/zenoss/zep/impl/EventProcessorImpl.java
@@ -158,8 +158,8 @@ public class EventProcessorImpl implements EventProcessor {
     @Resource(name="metrics")
     public void setBean( MetricRegistry metrics ) {
         this.metrics = metrics;
-        String preCreatePluginsTimerName = MetricRegistry.name(this.getClass().getCanonicalName(), "preCreatePlugins");
-        String postCreatePluginsTimerName = MetricRegistry.name(this.getClass().getCanonicalName(), "postCreatePlugins");
+        String preCreatePluginsTimerName = MetricRegistry.name("EventProcessorImpl", "preCreatePlugins");
+        String postCreatePluginsTimerName = MetricRegistry.name("EventProcessorImpl", "postCreatePlugins");
         // Set up timers for plugins
         preCreatePluginsTimer = metrics.timer(preCreatePluginsTimerName);
         postCreatePluginsTimer = metrics.timer(postCreatePluginsTimerName);

--- a/core/src/main/java/org/zenoss/zep/impl/TriggerPlugin.java
+++ b/core/src/main/java/org/zenoss/zep/impl/TriggerPlugin.java
@@ -10,6 +10,7 @@
 
 package org.zenoss.zep.impl;
 
+import com.codahale.metrics.annotation.Timed;
 import com.google.common.base.Splitter;
 import org.python.core.Py;
 import org.python.core.PyDictionary;
@@ -800,6 +801,7 @@ public class TriggerPlugin extends EventPostIndexPlugin {
         }
     }
 
+    @Timed(absolute=true, name="Trigger.publishSignal")
     protected void publishSignal(EventSummary eventSummary, EventTriggerSubscription subscription) throws ZepException {
         Event occurrence = eventSummary.getOccurrence(0);
         Signal.Builder signalBuilder = Signal.newBuilder();

--- a/core/src/main/java/org/zenoss/zep/index/impl/EventIndexerImpl.java
+++ b/core/src/main/java/org/zenoss/zep/index/impl/EventIndexerImpl.java
@@ -103,12 +103,12 @@ public class EventIndexerImpl implements EventIndexer, ApplicationListener<ZepCo
         String metricName = "";
         String pluginsTimerName = "";
         if(this.isSummary) {
-            metricName = MetricRegistry.name(this.getClass().getCanonicalName(), "summaryIndexedDocs");
-            pluginsTimerName = MetricRegistry.name(this.getClass().getCanonicalName(), "summaryPlugins");
+            metricName = MetricRegistry.name("EventIndexer", "summaryIndexedDocs");
+            pluginsTimerName = MetricRegistry.name("EventIndexer", "summaryPlugins");
         }
         else {
-            metricName = MetricRegistry.name(this.getClass().getCanonicalName(), "archiveIndexedDocs");
-            pluginsTimerName = MetricRegistry.name(this.getClass().getCanonicalName(), "archivePlugins");
+            metricName = MetricRegistry.name("EventIndexer", "archiveIndexedDocs");
+            pluginsTimerName = MetricRegistry.name("EventIndexer", "archivePlugins");
         }
         this.metrics.register(metricName, new Gauge<Long>() {
             @Override

--- a/core/src/main/java/org/zenoss/zep/index/impl/lucene/LuceneEventIndexBackend.java
+++ b/core/src/main/java/org/zenoss/zep/index/impl/lucene/LuceneEventIndexBackend.java
@@ -110,10 +110,10 @@ public class LuceneEventIndexBackend extends BaseEventIndexBackend<LuceneSavedSe
 
     private String getMetricName(String metricName) {
         if(this.archive) {
-            metricName = MetricRegistry.name(this.getClass().getCanonicalName(), "archive" + metricName);
+            metricName = MetricRegistry.name("LuceneEventIndexBackend", "archive" + metricName);
         }
         else {
-            metricName = MetricRegistry.name(this.getClass().getCanonicalName(), "summary" + metricName);
+            metricName = MetricRegistry.name("LuceneEventIndexBackend", "summary" + metricName);
         }
         return metricName;
     }


### PR DESCRIPTION
https://jira.zenoss.com/browse/ZEN-27970
In addition to the metric names for created by annotating functions, there were other metrics created through code.  This converts those to stable names.  The single exception is in AbstractQueueListener.java, which uses the implemented class name as part of the metric.  The new name will still match the pattern for the other metrics, however.