### PR TITLE
Changed a logback setting to disable logs we don't need.

### DIFF
--- a/core/src/main/resources/logback.xml
+++ b/core/src/main/resources/logback.xml
@@ -12,7 +12,7 @@
 
 
 <configuration scan="true">
-    <statusListener class="ch.qos.logback.core.status.OnConsoleStatusListener" />
+    <statusListener class="ch.qos.logback.core.status.NopStatusListener" />
 
     <if condition='isNull("ZENOSS_DAEMON")'>
         <then>


### PR DESCRIPTION
This in support of https://jira.zenoss.com/browse/ZEN-28080.  It removes the non compliant logs from Zeneventserver-stdio*.log.