### PR TITLE
ZEN-27179: raise log level

### DIFF
--- a/core/src/main/java/org/zenoss/zep/impl/Application.java
+++ b/core/src/main/java/org/zenoss/zep/impl/Application.java
@@ -382,7 +382,7 @@ public class Application implements ApplicationEventPublisherAware, ApplicationC
                             } catch (TransientDataAccessException e) {
                                 logger.debug("Failed to archive events", e);
                             } catch (Exception e) {
-                                logger.warn("Failed to archive events", e);
+                                logger.error("Failed to archive events", e);
                             }
                         }
                     }, "ZEP_EVENT_ARCHIVER"), startTime, archiveIntervalMilliseconds);

--- a/core/src/main/java/org/zenoss/zep/index/impl/EventIndexerImpl.java
+++ b/core/src/main/java/org/zenoss/zep/index/impl/EventIndexerImpl.java
@@ -137,7 +137,7 @@ public class EventIndexerImpl implements EventIndexer, ApplicationListener<ZepCo
                     } catch (ZepException e) {
                         logger.warn("Failed to index events", e);
                     } catch (Exception e) {
-                        logger.warn("General failure indexing events", e);
+                        logger.error("General failure indexing events", e);
                     }
                     // If we aren't shut down and we aren't processing a large backlog of events, wait to index the
                     // next batch of events after a delay.


### PR DESCRIPTION
When there is an index corruption and events cant be indexed
logs with Warn severity may be overlooked by users.
Raising log level from WARN to ERROR.

[JIRA](https://jira.zenoss.com/browse/ZEN-27179)