### PR TITLE
ZING-1117 instrumentation

### DIFF
--- a/core/src/main/java/org/zenoss/zep/zing/impl/ZingEmulatorPublisherImpl.java
+++ b/core/src/main/java/org/zenoss/zep/zing/impl/ZingEmulatorPublisherImpl.java
@@ -9,6 +9,7 @@
 
 package org.zenoss.zep.zing.impl;
 
+import com.codahale.metrics.MetricRegistry;
 import com.google.api.gax.core.CredentialsProvider;
 import com.google.api.gax.core.NoCredentialsProvider;
 import com.google.api.gax.grpc.GrpcTransportChannel;
@@ -36,8 +37,8 @@ public class ZingEmulatorPublisherImpl extends ZingPublisher {
 
     private AtomicBoolean everConnected;
 
-    public ZingEmulatorPublisherImpl(ZingConfig config) {
-        super(config);
+    public ZingEmulatorPublisherImpl(MetricRegistry metrics, ZingConfig config) {
+        super(metrics, config);
         logger.info("Creating Publisher to PubSub emulator");
         this.everConnected = new AtomicBoolean(false);
         this.setPublisher(this.buildPublisher(config));
@@ -102,11 +103,6 @@ public class ZingEmulatorPublisherImpl extends ZingPublisher {
             logger.error("Exception creating pubsub emulator publisher", e);
         }
         return publisher;
-    }
-
-    protected void onFailure(Throwable t)
-    {
-        logger.info("failed to publish to pubsub emulator: " + t);
     }
 
     public void publishEvent(ZingEvent event) {

--- a/core/src/main/java/org/zenoss/zep/zing/impl/ZingPublisherImpl.java
+++ b/core/src/main/java/org/zenoss/zep/zing/impl/ZingPublisherImpl.java
@@ -24,13 +24,14 @@ import java.io.IOException;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 
+import com.codahale.metrics.MetricRegistry;
 
 public class ZingPublisherImpl extends ZingPublisher {
 
     private static final Logger logger = LoggerFactory.getLogger(ZingPublisherImpl.class);
 
-    public ZingPublisherImpl(ZingConfig config) {
-        super(config);
+    public ZingPublisherImpl(MetricRegistry metrics, ZingConfig config) {
+        super(metrics, config);
         logger.info("Creating Publisher to GCP PubSub");
         this.setPublisher(this.buildPublisher(config));
     }
@@ -69,8 +70,8 @@ public class ZingPublisherImpl extends ZingPublisher {
 
     protected void onFailure(Throwable t)
     {
+        super.onFailure(t);
         // FIXME we need to store data somewhere to ensure zero data loss
-        logger.info("failed to publish to pubsub in GCP: " + t);
     }
 }
 


### PR DESCRIPTION
Added 3 counters and a timer. Example (attach to zep and `curl localhost:8084/zeneventserver/metrics/metrics?pretty=true`)
```
    "zing.bytesSent" : {
      "count" : 41295451
    },
    "zing.failedEvents" : {
      "count" : 0
    },
    "zing.invalidEvents" : {
      "count" : 0
    },
    "zing.sentEvents" : {
      "count" : 17271
    }
    "zing.processEvent" : {
      "count" : 17271,
      "max" : 0.0029335470000000003,
      "mean" : 7.203877821011673E-5,
      "min" : 3.0241E-5,
      "p50" : 3.4361000000000005E-5,
      "p75" : 3.9809000000000005E-5,
      "p95" : 1.6689604999999984E-4,
      "p98" : 6.032691799999988E-4,
      "p99" : 0.0010984998600000037,
      "p999" : 0.002912145116000003,
      "stddev" : 1.9470121733307908E-4,
      "m15_rate" : 38.99642614752441,
      "m1_rate" : 15.414639333926374,
      "m5_rate" : 30.1628053304724,
      "mean_rate" : 37.590989094638466,
      "duration_units" : "seconds",
      "rate_units" : "calls/second"
    }
```