### PR TITLE
ZEN-32683 Fixed paths for global.conf and zeneventserver.conf

### DIFF
--- a/core/src/main/resources/zep-config-cfg.xml
+++ b/core/src/main/resources/zep-config-cfg.xml
@@ -8,7 +8,7 @@
         class="org.springframework.beans.factory.config.PropertiesFactoryBean">
         <property name="locations">
             <array>
-                <value>file:etc/global.conf</value>
+                <value>file:/opt/zenoss/etc/global.conf</value>
             </array>
         </property>
         <property name="ignoreResourceNotFound" value="true" />
@@ -18,7 +18,7 @@
         <property name="locations">
             <array>
                 <value>classpath:zeneventserver.conf</value>
-                <value>file:etc/zeneventserver.conf</value>
+                <value>file:/opt/zenoss/etc/zeneventserver.conf</value>
             </array>
         </property>
         <property name="ignoreResourceNotFound" value="true" />


### PR DESCRIPTION
zeneventserver wasn't able to read configs because they have the wrong path. In result we can't configure zeneventserver using control center