### PR TITLE
ZING-9177: Add new Event messages from zing-proto

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ zep.log
 .checkedenv
 .checkedtools
 .checkedtools_version_brand
+
+core/.factorypath
+webapp/.factorypath

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
         <zenoss-utils.version>2.1.0</zenoss-utils.version>
         <zenoss-protocols.version>2.1.4</zenoss-protocols.version>
         <metric-consumer.version>0.0.16</metric-consumer.version>
-        <zing-proto.version>5.0.0</zing-proto.version>
+        <zing-proto.version>11.1.2</zing-proto.version>
         <protobuf.version>3.4.0</protobuf.version>
         <guava.version>21.0</guava.version>
         <pubsub.version>1.40.0</pubsub.version>


### PR DESCRIPTION
* We added new messages to zing-proto's event.proto fields which
  will match the additions to streaming data_receiver.proto fields.
* We don't modify any of the older message handling.
* This will support zing-proto 11.1.2 version