### PR TITLE
Updates to better support Java 11.

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -181,6 +181,13 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
+            <groupId>org.jboss.resteasy</groupId>
+            <artifactId>resteasy-jaxb-provider</artifactId>
+            <version>${version.resteasy}</version>
+            <type>jar</type>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-context</artifactId>
             <version>${version.spring}</version>

--- a/core/src/main/java/org/zenoss/zep/dao/impl/EventSummaryDaoImpl.java
+++ b/core/src/main/java/org/zenoss/zep/dao/impl/EventSummaryDaoImpl.java
@@ -250,7 +250,7 @@ public class EventSummaryDaoImpl implements EventSummaryDao {
                         while (!queued) {
                             List<Event> events = deduping.get(hashAsString);
                             if (events == null) {
-                                deduping.putIfAbsent(hashAsString, Collections.EMPTY_LIST);
+                                deduping.putIfAbsent(hashAsString, Collections.emptyList());
                                 continue;
                             }
                             List<Event> newEvents = Lists.newArrayList(events);
@@ -273,7 +273,7 @@ public class EventSummaryDaoImpl implements EventSummaryDao {
                         synchronized (hashAsString) {
                             List<Event> events = deduping.remove(hashAsString);
                             if (events == null)
-                                events = Collections.EMPTY_LIST;
+                                events = Collections.emptyList();
                             return saveEventByFingerprint(fingerprintHash, events, context, createClearHash);
                         }
                     }

--- a/dist/src/assembly/bin/zeneventserver
+++ b/dist/src/assembly/bin/zeneventserver
@@ -13,8 +13,13 @@
 ZEPDIR=${ZENHOME}/webapps/zeneventserver
 ZEP_WEB_XML=${ZEPDIR}/WEB-INF/web.xml
 
+dev_run() {
+	local options="-DskipTests=true -Djetty.port=8084 -Dzep.index.dir=/opt/zenoss/var/zeneventserver/index"
+	local opts="--add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.nio=ALL-UNNAMED"
+	MAVEN_OPTS="${opts}" mvn ${options} clean jetty:run
+}
+
 if [ ! -f ${ZEP_WEB_XML} ]; then
-   DEV_MVN_RUN="mvn -DskipTests=true -Djetty.port=8084 -Dzep.index.dir=/opt/zenoss/var/zeneventserver/index clean jetty:run"
    # if web.xml doesn't exists we might be in dev mode
    # cd into zep directory and try to run via maven
    set -e
@@ -22,15 +27,15 @@ if [ ! -f ${ZEP_WEB_XML} ]; then
    CMD=$1
    case "$CMD" in
       run)
-         ${DEV_MVN_RUN}
+         dev_run
          exit
          ;;
       run_quiet)
-         ${DEV_MVN_RUN} >${ZENHOME}/log/zeneventserver.log 2>&1
+         dev_run >${ZENHOME}/log/zeneventserver.log 2>&1
          exit
          ;;
       start)
-         ${DEV_MVN_RUN} >${ZENHOME}/log/zeneventserver.log 2>&1 &
+         dev_run >${ZENHOME}/log/zeneventserver.log 2>&1 &
 	      n=0
 	      while [ $n -lt 150 ]
 	      do

--- a/dist/src/assembly/bin/zeneventserver-functions.sh
+++ b/dist/src/assembly/bin/zeneventserver-functions.sh
@@ -13,6 +13,12 @@
 JETTYSTART_JAR=`ls -1 ${JETTY_HOME}/lib/jetty-start*.jar`
 PS="ps"
 
+# Add --add-opens args to open modules to pre-module code.
+OPEN_PACKAGES="java.base/java.lang java.base/java.nio"
+for pkg in ${OPEN_PACKAGES}; do
+	JVM_ARGS="${JVM_ARGS} --add-opens ${pkg}=ALL-UNNAMED"
+done
+
 get_pid() {
     if [ -f $PIDFILE ]; then
         local pid=`cat $PIDFILE 2>/dev/null`
@@ -28,6 +34,7 @@ run() {
     PID=$$
     rm -f $PIDFILE
     echo $PID > $PIDFILE
+    JVM_ARGS="$JVM_ARGS -DZENOSS_DAEMON=y"
     exec java ${JVM_ARGS} -XX:OnOutOfMemoryError="kill -9 %p" -jar ${JETTYSTART_JAR} ${JETTY_ARGS} ${RUN_ARGS}
 }
 

--- a/makefile
+++ b/makefile
@@ -1,0 +1,11 @@
+
+packages = java.base/java.util java.base/java.text java.desktop/java.awt.font
+add_opens = $(foreach pkg,$(packages),--add-opens $(pkg)=ALL-UNNAMED)
+
+.PHONY: package clean
+
+package:
+	@MAVEN_OPTS="$(add_opens)" mvn package
+
+clean:
+	@mvn clean

--- a/pom.xml
+++ b/pom.xml
@@ -148,10 +148,10 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.3.2</version>
+                <version>3.1</version>
                 <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                 <compilerArgs>
                   <arg>-Xlint:all</arg>
                 </compilerArgs>
@@ -169,17 +169,17 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>versions-maven-plugin</artifactId>
-                <version>1.2</version>
+                <version>2.8.1</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.8</version>
+                <version>2.22.2</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>2.1.2</version>
+                <version>3.2.1</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>


### PR DESCRIPTION
* Updated some plugins to later releases.
* Add --add-opens to various scripts to handle illegal access warnings while using reflection.
* Include a jaxb provider dependency that was included by default in Java 8.

Fixes ZEN-33057.